### PR TITLE
Remove multiple errors option in comment

### DIFF
--- a/exercises/03.schema-validation/02.problem.conform-action/app/routes/users+/$username_+/notes.$noteId_.edit.tsx
+++ b/exercises/03.schema-validation/02.problem.conform-action/app/routes/users+/$username_+/notes.$noteId_.edit.tsx
@@ -46,8 +46,7 @@ export async function action({ request, params }: DataFunctionArgs) {
 	const formData = await request.formData()
 
 	// 🐨 swap this for parse from conform, passing the formData as the first argument
-	// 🐨 For the options, provide NoteEditorSchema as the "schema" and let's
-	// enable the multiple errors option with "acceptMultipleErrors: () => true"
+	// 🐨 For the options, provide NoteEditorSchema as the "schema"
 	// 🦉 it's common convention to call the variable assigned to the parse call "submission"
 	const result = NoteEditorSchema.safeParse({
 		title: formData.get('title'),


### PR DESCRIPTION
It looks like conform release v0.8.0 removed the acceptMultipleErrors option as this is now the default. Removing the comment might avoid any confusion for other students. https://github.com/edmundhung/conform/releases/tag/v0.8.0