### PR TITLE
Fix conform comment for textarea field

### DIFF
--- a/exercises/03.schema-validation/03.problem.conform-form/app/routes/users+/$username_+/notes.$noteId_.edit.tsx
+++ b/exercises/03.schema-validation/03.problem.conform-form/app/routes/users+/$username_+/notes.$noteId_.edit.tsx
@@ -166,7 +166,7 @@ export default function NoteEdit() {
 							aria-invalid={contentHasErrors || undefined}
 							aria-describedby={contentErrorId}
 							// 💣 everything between here and the previous 💣 can be deleted
-							// 🐨 add {...conform.input(fields.content)} here
+							// 🐨 add {...conform.textarea(fields.content)} here
 						/>
 						<div className="min-h-[32px] px-4 pb-3 pt-1">
 							{/* 🐨 get the id from fields.content.errorId */}


### PR DESCRIPTION
The comment was specifying to add `{...conform.input(fields.content)}`, but since the form field is a textarea it ought to have been suggesting `{...conform.textarea(fields.content)}`.

This just updates the hint so that it shows the appropriate version for the form field type, and matches the code that the solution to the exercise uses.