### PR TITLE
Fix instruction for file input label htmlFor update

### DIFF
--- a/exercises/05.complex-structures/01.problem.nested/app/routes/users+/$username_+/notes.$noteId_.edit.tsx
+++ b/exercises/05.complex-structures/01.problem.nested/app/routes/users+/$username_+/notes.$noteId_.edit.tsx
@@ -211,7 +211,7 @@ function ImageChooser({
 				<div className="w-32">
 					<div className="relative h-32 w-32">
 						<label
-							// 🐨 update this htmlFor to reference fields.id.id
+							// 🐨 update this htmlFor to reference fields.file.id
 							htmlFor="image-input"
 							className={cn('group absolute h-32 w-32 rounded-lg', {
 								'bg-accent opacity-40 focus-within:opacity-100 hover:opacity-100':


### PR DESCRIPTION
The label is currently linked to the file input of the form, but the comment/instructions on changes to be made accidentally specified to link it to the image id input field (which is a hidden field).

This updates the comment so that it specifies the correct form input field as per the previous example and the solution for this example.