### PR TITLE
fix typo in README.mdx

### DIFF
--- a/exercises/06.honeypot/02.problem.util/README.mdx
+++ b/exercises/06.honeypot/02.problem.util/README.mdx
@@ -42,7 +42,7 @@ try {
 
 The `SpamError` comes from `remix-utils/honeypot/server`.
 
-And then for the UI, you can remove our custom `input` stuff with
+And then for the UI, you can replace our custom `input` stuff with
 `<HoneypotInputs />` from `remix-utils/honeypot/react`.
 
 Good luck!


### PR DESCRIPTION
"replace" instead of "remove" at the very end of the file.