### PR TITLE
Change "inside" to "above" in first accessibility lesson about labels

### DIFF
--- a/exercises/02.accessibility/01.problem.labels/README.mdx
+++ b/exercises/02.accessibility/01.problem.labels/README.mdx
@@ -14,7 +14,7 @@ not associated with each other. So it should be something like this:
 ```
 
 You can test out whether your changes fixed the problem by clicking on the label
-text inside the input. If the input is focused, then you've done it! If not,
+text above the input. If the input is focused, then you've done it! If not,
 then there's still more work to do.
 
 Another issue we've got is the "Reset" button doesn't work. This is because, due


### PR DESCRIPTION
I did a double-take when I read this sentence in the accessibility lesson. The `<label>` element itself is completely above the `<input>` element as a sibling in the DOM, so I think this edit helps. Alternatively, I think "clicking text inside the label" would clear up my confusion, too.