### PR TITLE
Fix anchor name in link to remix-utils form-honeypot

### DIFF
--- a/exercises/06.honeypot/README.mdx
+++ b/exercises/06.honeypot/README.mdx
@@ -145,4 +145,4 @@ const honeyProps = honeypot.getInputProps()
 honeypot.check(formData)
 ```
 
-- [📜 `remix-utils` Honeypot](https://github.com/sergiodxa/remix-utils#honeypot)
+- [📜 `remix-utils` Honeypot](https://github.com/sergiodxa/remix-utils#form-honeypot)


### PR DESCRIPTION
The closing link at the end of the intro to Honeypot lesson tries to jump down in the README, but it looks like the anchor name may have changed since the workshop was initially published.