### PR TITLE
fix: add condition to re-trigger focus upon new submissions

### DIFF
--- a/exercises/03.schema-validation/01.problem.zod/app/routes/users+/$username_+/notes.$noteId_.edit.tsx
+++ b/exercises/03.schema-validation/01.problem.zod/app/routes/users+/$username_+/notes.$noteId_.edit.tsx
@@ -147,7 +147,10 @@ export default function NoteEdit() {
 	const contentHasErrors = Boolean(fieldErrors?.content.length)
 	const contentErrorId = contentHasErrors ? 'content-error' : undefined
 
-	useFocusInvalid(formRef.current, actionData?.status === 'error')
+	useFocusInvalid(
+		formRef.current,
+		actionData?.status === 'error' && !isSubmitting,
+	)
 
 	return (
 		<div className="absolute inset-0">

--- a/exercises/03.schema-validation/01.solution.zod/app/routes/users+/$username_+/notes.$noteId_.edit.tsx
+++ b/exercises/03.schema-validation/01.solution.zod/app/routes/users+/$username_+/notes.$noteId_.edit.tsx
@@ -106,7 +106,10 @@ export default function NoteEdit() {
 	const contentHasErrors = Boolean(fieldErrors?.content?.length)
 	const contentErrorId = contentHasErrors ? 'content-error' : undefined
 
-	useFocusInvalid(formRef.current, actionData?.status === 'error')
+	useFocusInvalid(
+		formRef.current,
+		actionData?.status === 'error' && !isSubmitting,
+	)
 
 	return (
 		<div className="absolute inset-0">

--- a/exercises/03.schema-validation/02.problem.conform-action/app/routes/users+/$username_+/notes.$noteId_.edit.tsx
+++ b/exercises/03.schema-validation/02.problem.conform-action/app/routes/users+/$username_+/notes.$noteId_.edit.tsx
@@ -119,7 +119,10 @@ export default function NoteEdit() {
 	const contentHasErrors = Boolean(fieldErrors?.content?.length)
 	const contentErrorId = contentHasErrors ? 'content-error' : undefined
 
-	useFocusInvalid(formRef.current, actionData?.status === 'error')
+	useFocusInvalid(
+		formRef.current,
+		actionData?.status === 'error' && !isSubmitting,
+	)
 
 	return (
 		<div className="absolute inset-0">

--- a/exercises/03.schema-validation/02.solution.conform-action/app/routes/users+/$username_+/notes.$noteId_.edit.tsx
+++ b/exercises/03.schema-validation/02.solution.conform-action/app/routes/users+/$username_+/notes.$noteId_.edit.tsx
@@ -103,7 +103,10 @@ export default function NoteEdit() {
 	const contentHasErrors = Boolean(fieldErrors?.content?.length)
 	const contentErrorId = contentHasErrors ? 'content-error' : undefined
 
-	useFocusInvalid(formRef.current, actionData?.status === 'error')
+	useFocusInvalid(
+		formRef.current,
+		actionData?.status === 'error' && !isSubmitting,
+	)
 
 	return (
 		<div className="absolute inset-0">

--- a/exercises/03.schema-validation/03.problem.conform-form/app/routes/users+/$username_+/notes.$noteId_.edit.tsx
+++ b/exercises/03.schema-validation/03.problem.conform-form/app/routes/users+/$username_+/notes.$noteId_.edit.tsx
@@ -107,7 +107,10 @@ export default function NoteEdit() {
 	const contentHasErrors = Boolean(fieldErrors?.content?.length)
 	const contentErrorId = contentHasErrors ? 'content-error' : undefined
 
-	useFocusInvalid(formRef.current, actionData?.status === 'error')
+	useFocusInvalid(
+		formRef.current,
+		actionData?.status === 'error' && !isSubmitting,
+	)
 	// 💣 delete everything between here and the previous 💣
 	// Conform does a lot for us huh!? 🤯
 


### PR DESCRIPTION
When using the hook `useFocusInvalid`, introduced in _Schema Validation lesson 01. Zod schema validation_, we have a problem: The `actionData.status` is always equals to `'error'`, which means the `useEffect` only runs once. This leads us not having the focus being set properly after the second "invalid" submission attempt:

https://github.com/epicweb-dev/web-forms/assets/46943072/91426e67-f44f-4536-8049-67e1410357d4

_* Just a note that this was not occurring in the previous lessons, as `actionData` was used as a dependency and therefore was new after every submission_

The proposed solution is simply to add is to add `isSubmitting` in the boolean that forms `hasErrors`, so we can have the `useEffect` running after every submission:

https://github.com/epicweb-dev/web-forms/assets/46943072/e4b46352-4c6b-461a-bd9f-25539203d13c


