### PR TITLE
Set ARIA acronym to uppercase in title

### DIFF
--- a/exercises/02.accessibility/02.problem.aria/README.mdx
+++ b/exercises/02.accessibility/02.problem.aria/README.mdx
@@ -1,4 +1,4 @@
-# Validation aria attributes
+# Validation ARIA attributes
 
 <EpicVideo url="https://www.epicweb.dev/workshops/professional-web-forms/accessibility/enhancing-error-messages-and-accessibility-with-aria-attributes" />
 


### PR DESCRIPTION
Since ARIA is an acronym, it would make sense to write it in all lowercase.