### PR TITLE
chore: Add vscode workspace

### DIFF
--- a/.vscode/workspaces/playground.code-workspace
+++ b/.vscode/workspaces/playground.code-workspace
@@ -1,0 +1,17 @@
+{
+	"folders": [
+		{
+			"name": "playground",
+			"path": "../../playground"
+		}
+	],
+	"settings": {
+		"terminal.integrated.cwd": "../",
+		"typescript.preferences.autoImportFileExcludePatterns": [
+			"@remix-run/server-runtime",
+			"@remix-run/router",
+			"react-router-dom",
+			"react-router"
+		]
+	}
+}


### PR DESCRIPTION
Sometimes, it can be a bit inconvenient to work with a non-root directory open in VSCode (in this case, `/workspace`), as some functionalities, such as search, terminal and replace, don't work ideally. Would it be interesting to consider adding support for the [workspace feature in VSCode?](https://code.visualstudio.com/docs/editor/workspaces) This way, the terminal would open in the root directory, while the visible directories would be limited to "/playground," significantly optimizing the workshop experience

![Screen Recording 2024-02-04 at 9 34 08 PM](https://github.com/epicweb-dev/web-forms/assets/32820963/3a393e84-3093-451f-8b12-d03a2a8e7747)


