### PR TITLE
Adds a Note about the benefits of including aria-invalid=false explicitly

### DIFF
--- a/exercises/02.accessibility/02.solution.aria/README.mdx
+++ b/exercises/02.accessibility/02.solution.aria/README.mdx
@@ -8,8 +8,17 @@ specific fields and it knows which fields are invalid thanks to
 non-screen reader users) navigate more efficiently to the field that has an
 error, so let's do that next.
 
-
 <callout-info class="aside">
-	Note: Including `aria-invalid="false"` is actually recommended over not including it at all. When `aria-invalid="false"` is explicitly provided, it ensures that the screen reader conveys to the user that the input is valid, which can help in reducing confusion and providing clear feedback. Some screen readers might interpret the absence of `aria-invalid` as an indication that the validity is unknown and may not provide any specific feedback regarding validation errors or validity status. Others might infer the validity based on other cues in the document, such as HTML5 validation attributes (required, pattern, etc.) or contextual clues, but this behavior isn't guaranteed across all screen readers.
-	
+	Note: Including `aria-invalid="false"` is actually recommended over not
+	including it at all. When `aria-invalid="false"` is explicitly provided, it
+	ensures that the screen reader conveys to the user that the input is valid,
+	which can help in reducing confusion and providing clear feedback. Some screen
+	readers might interpret the absence of `aria-invalid` as an indication that
+	the validity is unknown and may not provide any specific feedback regarding
+	validation errors or validity status. Others might infer the validity based on
+	other cues in the document, such as HTML5 validation attributes (required,
+	pattern, etc.) or contextual clues, but this behavior isn't guaranteed across
+	all screen readers. Screen readers are definitely at the level of consistency
+	with one other that browsers were in the early 2000s 😱 so it's a challenge to
+	keep up with all the nuances.
 </callout-info>

--- a/exercises/02.accessibility/02.solution.aria/README.mdx
+++ b/exercises/02.accessibility/02.solution.aria/README.mdx
@@ -7,3 +7,9 @@ specific fields and it knows which fields are invalid thanks to
 `aria-invalid="true"`. But we still need to help the screen reader user (and
 non-screen reader users) navigate more efficiently to the field that has an
 error, so let's do that next.
+
+
+<callout-info class="aside">
+	Note: Including `aria-invalid="false"` is actually recommended over not including it at all. When `aria-invalid="false"` is explicitly provided, it ensures that the screen reader conveys to the user that the input is valid, which can help in reducing confusion and providing clear feedback. Some screen readers might interpret the absence of `aria-invalid` as an indication that the validity is unknown and may not provide any specific feedback regarding validation errors or validity status. Others might infer the validity based on other cues in the document, such as HTML5 validation attributes (required, pattern, etc.) or contextual clues, but this behavior isn't guaranteed across all screen readers.
+	
+</callout-info>


### PR DESCRIPTION
Hey 👋

As mentioned in Discord in the solution video for exercise 2-2 (Validation ARIA attributes), it's been said that we shouldn't include the `aria-invalid` attribute when it's valid because of differences in screen readers' behaviors. But it's actually recommended that we do so because it provides more information to screen readers. Some may require that info for their functioning, and others can improve the experience by explicitly informing the validity. 

This note is kinda long, please let me know if I should change/remove something
<img width="667" alt="image" src="https://github.com/epicweb-dev/web-forms/assets/26825991/8a57b834-bf08-4fbc-86d9-6302c6f59c1f">
