### PR TITLE
Updates conform-to/react link to conform Remix integration link

### DIFF
--- a/exercises/03.schema-validation/03.problem.conform-form/README.mdx
+++ b/exercises/03.schema-validation/03.problem.conform-form/README.mdx
@@ -104,5 +104,5 @@ const [form, fields] = useForm({
 })
 ```
 
-- [📜 `@conform-to/react`](https://conform.guide/api/react)
+- [📜 Conform Remix Integration](https://conform.guide/integration/remix)
 - [📜 Conform Accessibility](https://conform.guide/accessibility)


### PR DESCRIPTION
Conform docs got updated, and the `@conform-to/react` page was removed. As there is no index route for that package, we're replacing that link with the Remix integration that documents both client and server, using that package