### PR TITLE
Update db.server.ts

### DIFF
--- a/exercises/05.complex-structures/01.solution.nested/app/utils/db.server.ts
+++ b/exercises/05.complex-structures/01.solution.nested/app/utils/db.server.ts
@@ -169,6 +169,7 @@ export async function updateNote({
 						id,
 						filepath,
 						altText: image.altText,
+						contentType: image?.file?.type,
 					},
 				})
 			} else if (image.file) {


### PR DESCRIPTION
When selecting an SVG image and editing the note, the image updates correctly. However, switching to a different format (e.g., JPEG) later causes a placeholder to appear in the image picker because the `contentType` was not being updated.

This fix modifies `db.image.update` to include `contentType: image.file?.type`, ensuring the correct file type is stored and displayed when changing formats.