### PR TITLE
Issue 56 reproduction

### DIFF
--- a/exercises/01.form-validation/01.problem.form-validation/package.json
+++ b/exercises/01.form-validation/01.problem.form-validation/package.json
@@ -65,6 +65,7 @@
     "esbuild": "^0.19.5",
     "eslint": "^8.51.0",
     "eslint-config-prettier": "^9.0.0",
+    "execa": "^9.6.1",
     "fs-extra": "^11.1.1",
     "npm-run-all": "^4.1.5",
     "postcss": "^8.4.31",

--- a/exercises/01.form-validation/01.solution.form-validation/package.json
+++ b/exercises/01.form-validation/01.solution.form-validation/package.json
@@ -65,6 +65,7 @@
     "esbuild": "^0.19.5",
     "eslint": "^8.51.0",
     "eslint-config-prettier": "^9.0.0",
+    "execa": "^9.6.1",
     "fs-extra": "^11.1.1",
     "npm-run-all": "^4.1.5",
     "postcss": "^8.4.31",

--- a/exercises/01.form-validation/02.problem.server-validation/package.json
+++ b/exercises/01.form-validation/02.problem.server-validation/package.json
@@ -65,6 +65,7 @@
     "esbuild": "^0.19.5",
     "eslint": "^8.51.0",
     "eslint-config-prettier": "^9.0.0",
+    "execa": "^9.6.1",
     "fs-extra": "^11.1.1",
     "npm-run-all": "^4.1.5",
     "postcss": "^8.4.31",

--- a/exercises/01.form-validation/02.solution.server-validation/package.json
+++ b/exercises/01.form-validation/02.solution.server-validation/package.json
@@ -65,6 +65,7 @@
     "esbuild": "^0.19.5",
     "eslint": "^8.51.0",
     "eslint-config-prettier": "^9.0.0",
+    "execa": "^9.6.1",
     "fs-extra": "^11.1.1",
     "npm-run-all": "^4.1.5",
     "postcss": "^8.4.31",

--- a/exercises/01.form-validation/03.problem.no-validate/package.json
+++ b/exercises/01.form-validation/03.problem.no-validate/package.json
@@ -65,6 +65,7 @@
     "esbuild": "^0.19.5",
     "eslint": "^8.51.0",
     "eslint-config-prettier": "^9.0.0",
+    "execa": "^9.6.1",
     "fs-extra": "^11.1.1",
     "npm-run-all": "^4.1.5",
     "postcss": "^8.4.31",

--- a/exercises/01.form-validation/03.solution.no-validate/package.json
+++ b/exercises/01.form-validation/03.solution.no-validate/package.json
@@ -65,6 +65,7 @@
     "esbuild": "^0.19.5",
     "eslint": "^8.51.0",
     "eslint-config-prettier": "^9.0.0",
+    "execa": "^9.6.1",
     "fs-extra": "^11.1.1",
     "npm-run-all": "^4.1.5",
     "postcss": "^8.4.31",

--- a/exercises/02.accessibility/01.problem.labels/package.json
+++ b/exercises/02.accessibility/01.problem.labels/package.json
@@ -65,6 +65,7 @@
     "esbuild": "^0.19.5",
     "eslint": "^8.51.0",
     "eslint-config-prettier": "^9.0.0",
+    "execa": "^9.6.1",
     "fs-extra": "^11.1.1",
     "npm-run-all": "^4.1.5",
     "postcss": "^8.4.31",

--- a/exercises/02.accessibility/01.solution.labels/package.json
+++ b/exercises/02.accessibility/01.solution.labels/package.json
@@ -65,6 +65,7 @@
     "esbuild": "^0.19.5",
     "eslint": "^8.51.0",
     "eslint-config-prettier": "^9.0.0",
+    "execa": "^9.6.1",
     "fs-extra": "^11.1.1",
     "npm-run-all": "^4.1.5",
     "postcss": "^8.4.31",

--- a/exercises/02.accessibility/02.problem.aria/package.json
+++ b/exercises/02.accessibility/02.problem.aria/package.json
@@ -65,6 +65,7 @@
     "esbuild": "^0.19.5",
     "eslint": "^8.51.0",
     "eslint-config-prettier": "^9.0.0",
+    "execa": "^9.6.1",
     "fs-extra": "^11.1.1",
     "npm-run-all": "^4.1.5",
     "postcss": "^8.4.31",

--- a/exercises/02.accessibility/02.solution.aria/package.json
+++ b/exercises/02.accessibility/02.solution.aria/package.json
@@ -65,6 +65,7 @@
     "esbuild": "^0.19.5",
     "eslint": "^8.51.0",
     "eslint-config-prettier": "^9.0.0",
+    "execa": "^9.6.1",
     "fs-extra": "^11.1.1",
     "npm-run-all": "^4.1.5",
     "postcss": "^8.4.31",

--- a/exercises/02.accessibility/03.problem.focus/package.json
+++ b/exercises/02.accessibility/03.problem.focus/package.json
@@ -65,6 +65,7 @@
     "esbuild": "^0.19.5",
     "eslint": "^8.51.0",
     "eslint-config-prettier": "^9.0.0",
+    "execa": "^9.6.1",
     "fs-extra": "^11.1.1",
     "npm-run-all": "^4.1.5",
     "postcss": "^8.4.31",

--- a/exercises/02.accessibility/03.solution.focus/package.json
+++ b/exercises/02.accessibility/03.solution.focus/package.json
@@ -65,6 +65,7 @@
     "esbuild": "^0.19.5",
     "eslint": "^8.51.0",
     "eslint-config-prettier": "^9.0.0",
+    "execa": "^9.6.1",
     "fs-extra": "^11.1.1",
     "npm-run-all": "^4.1.5",
     "postcss": "^8.4.31",

--- a/exercises/03.schema-validation/01.problem.zod/package.json
+++ b/exercises/03.schema-validation/01.problem.zod/package.json
@@ -65,6 +65,7 @@
     "esbuild": "^0.19.5",
     "eslint": "^8.51.0",
     "eslint-config-prettier": "^9.0.0",
+    "execa": "^9.6.1",
     "fs-extra": "^11.1.1",
     "npm-run-all": "^4.1.5",
     "postcss": "^8.4.31",

--- a/exercises/03.schema-validation/01.solution.zod/package.json
+++ b/exercises/03.schema-validation/01.solution.zod/package.json
@@ -65,6 +65,7 @@
     "esbuild": "^0.19.5",
     "eslint": "^8.51.0",
     "eslint-config-prettier": "^9.0.0",
+    "execa": "^9.6.1",
     "fs-extra": "^11.1.1",
     "npm-run-all": "^4.1.5",
     "postcss": "^8.4.31",

--- a/exercises/03.schema-validation/02.problem.conform-action/package.json
+++ b/exercises/03.schema-validation/02.problem.conform-action/package.json
@@ -65,6 +65,7 @@
     "esbuild": "^0.19.5",
     "eslint": "^8.51.0",
     "eslint-config-prettier": "^9.0.0",
+    "execa": "^9.6.1",
     "fs-extra": "^11.1.1",
     "npm-run-all": "^4.1.5",
     "postcss": "^8.4.31",

--- a/exercises/03.schema-validation/02.solution.conform-action/package.json
+++ b/exercises/03.schema-validation/02.solution.conform-action/package.json
@@ -65,6 +65,7 @@
     "esbuild": "^0.19.5",
     "eslint": "^8.51.0",
     "eslint-config-prettier": "^9.0.0",
+    "execa": "^9.6.1",
     "fs-extra": "^11.1.1",
     "npm-run-all": "^4.1.5",
     "postcss": "^8.4.31",

--- a/exercises/03.schema-validation/03.problem.conform-form/package.json
+++ b/exercises/03.schema-validation/03.problem.conform-form/package.json
@@ -65,6 +65,7 @@
     "esbuild": "^0.19.5",
     "eslint": "^8.51.0",
     "eslint-config-prettier": "^9.0.0",
+    "execa": "^9.6.1",
     "fs-extra": "^11.1.1",
     "npm-run-all": "^4.1.5",
     "postcss": "^8.4.31",

--- a/exercises/03.schema-validation/03.solution.conform-form/package.json
+++ b/exercises/03.schema-validation/03.solution.conform-form/package.json
@@ -65,6 +65,7 @@
     "esbuild": "^0.19.5",
     "eslint": "^8.51.0",
     "eslint-config-prettier": "^9.0.0",
+    "execa": "^9.6.1",
     "fs-extra": "^11.1.1",
     "npm-run-all": "^4.1.5",
     "postcss": "^8.4.31",

--- a/exercises/04.file-upload/01.problem.multi-part/package.json
+++ b/exercises/04.file-upload/01.problem.multi-part/package.json
@@ -65,6 +65,7 @@
     "esbuild": "^0.19.5",
     "eslint": "^8.51.0",
     "eslint-config-prettier": "^9.0.0",
+    "execa": "^9.6.1",
     "fs-extra": "^11.1.1",
     "npm-run-all": "^4.1.5",
     "postcss": "^8.4.31",

--- a/exercises/04.file-upload/01.solution.multi-part/package.json
+++ b/exercises/04.file-upload/01.solution.multi-part/package.json
@@ -65,6 +65,7 @@
     "esbuild": "^0.19.5",
     "eslint": "^8.51.0",
     "eslint-config-prettier": "^9.0.0",
+    "execa": "^9.6.1",
     "fs-extra": "^11.1.1",
     "npm-run-all": "^4.1.5",
     "postcss": "^8.4.31",

--- a/exercises/04.file-upload/02.problem.file-validation/package.json
+++ b/exercises/04.file-upload/02.problem.file-validation/package.json
@@ -65,6 +65,7 @@
     "esbuild": "^0.19.5",
     "eslint": "^8.51.0",
     "eslint-config-prettier": "^9.0.0",
+    "execa": "^9.6.1",
     "fs-extra": "^11.1.1",
     "npm-run-all": "^4.1.5",
     "postcss": "^8.4.31",

--- a/exercises/04.file-upload/02.solution.file-validation/package.json
+++ b/exercises/04.file-upload/02.solution.file-validation/package.json
@@ -65,6 +65,7 @@
     "esbuild": "^0.19.5",
     "eslint": "^8.51.0",
     "eslint-config-prettier": "^9.0.0",
+    "execa": "^9.6.1",
     "fs-extra": "^11.1.1",
     "npm-run-all": "^4.1.5",
     "postcss": "^8.4.31",

--- a/exercises/05.complex-structures/01.problem.nested/package.json
+++ b/exercises/05.complex-structures/01.problem.nested/package.json
@@ -65,6 +65,7 @@
     "esbuild": "^0.19.5",
     "eslint": "^8.51.0",
     "eslint-config-prettier": "^9.0.0",
+    "execa": "^9.6.1",
     "fs-extra": "^11.1.1",
     "npm-run-all": "^4.1.5",
     "postcss": "^8.4.31",

--- a/exercises/05.complex-structures/01.solution.nested/package.json
+++ b/exercises/05.complex-structures/01.solution.nested/package.json
@@ -65,6 +65,7 @@
     "esbuild": "^0.19.5",
     "eslint": "^8.51.0",
     "eslint-config-prettier": "^9.0.0",
+    "execa": "^9.6.1",
     "fs-extra": "^11.1.1",
     "npm-run-all": "^4.1.5",
     "postcss": "^8.4.31",

--- a/exercises/05.complex-structures/02.problem.lists/package.json
+++ b/exercises/05.complex-structures/02.problem.lists/package.json
@@ -65,6 +65,7 @@
     "esbuild": "^0.19.5",
     "eslint": "^8.51.0",
     "eslint-config-prettier": "^9.0.0",
+    "execa": "^9.6.1",
     "fs-extra": "^11.1.1",
     "npm-run-all": "^4.1.5",
     "postcss": "^8.4.31",

--- a/exercises/05.complex-structures/02.solution.lists/package.json
+++ b/exercises/05.complex-structures/02.solution.lists/package.json
@@ -65,6 +65,7 @@
     "esbuild": "^0.19.5",
     "eslint": "^8.51.0",
     "eslint-config-prettier": "^9.0.0",
+    "execa": "^9.6.1",
     "fs-extra": "^11.1.1",
     "npm-run-all": "^4.1.5",
     "postcss": "^8.4.31",

--- a/exercises/05.complex-structures/03.problem.add-remove/package.json
+++ b/exercises/05.complex-structures/03.problem.add-remove/package.json
@@ -65,6 +65,7 @@
     "esbuild": "^0.19.5",
     "eslint": "^8.51.0",
     "eslint-config-prettier": "^9.0.0",
+    "execa": "^9.6.1",
     "fs-extra": "^11.1.1",
     "npm-run-all": "^4.1.5",
     "postcss": "^8.4.31",

--- a/exercises/05.complex-structures/03.solution.add-remove/package.json
+++ b/exercises/05.complex-structures/03.solution.add-remove/package.json
@@ -65,6 +65,7 @@
     "esbuild": "^0.19.5",
     "eslint": "^8.51.0",
     "eslint-config-prettier": "^9.0.0",
+    "execa": "^9.6.1",
     "fs-extra": "^11.1.1",
     "npm-run-all": "^4.1.5",
     "postcss": "^8.4.31",

--- a/exercises/06.honeypot/01.problem.basic/package.json
+++ b/exercises/06.honeypot/01.problem.basic/package.json
@@ -65,6 +65,7 @@
     "esbuild": "^0.19.5",
     "eslint": "^8.51.0",
     "eslint-config-prettier": "^9.0.0",
+    "execa": "^9.6.1",
     "fs-extra": "^11.1.1",
     "npm-run-all": "^4.1.5",
     "postcss": "^8.4.31",

--- a/exercises/06.honeypot/01.solution.basic/package.json
+++ b/exercises/06.honeypot/01.solution.basic/package.json
@@ -65,6 +65,7 @@
     "esbuild": "^0.19.5",
     "eslint": "^8.51.0",
     "eslint-config-prettier": "^9.0.0",
+    "execa": "^9.6.1",
     "fs-extra": "^11.1.1",
     "npm-run-all": "^4.1.5",
     "postcss": "^8.4.31",

--- a/exercises/06.honeypot/02.problem.util/package.json
+++ b/exercises/06.honeypot/02.problem.util/package.json
@@ -65,6 +65,7 @@
     "esbuild": "^0.19.5",
     "eslint": "^8.51.0",
     "eslint-config-prettier": "^9.0.0",
+    "execa": "^9.6.1",
     "fs-extra": "^11.1.1",
     "npm-run-all": "^4.1.5",
     "postcss": "^8.4.31",

--- a/exercises/06.honeypot/02.solution.util/package.json
+++ b/exercises/06.honeypot/02.solution.util/package.json
@@ -65,6 +65,7 @@
     "esbuild": "^0.19.5",
     "eslint": "^8.51.0",
     "eslint-config-prettier": "^9.0.0",
+    "execa": "^9.6.1",
     "fs-extra": "^11.1.1",
     "npm-run-all": "^4.1.5",
     "postcss": "^8.4.31",

--- a/exercises/06.honeypot/03.problem.provider/package.json
+++ b/exercises/06.honeypot/03.problem.provider/package.json
@@ -65,6 +65,7 @@
     "esbuild": "^0.19.5",
     "eslint": "^8.51.0",
     "eslint-config-prettier": "^9.0.0",
+    "execa": "^9.6.1",
     "fs-extra": "^11.1.1",
     "npm-run-all": "^4.1.5",
     "postcss": "^8.4.31",

--- a/exercises/06.honeypot/03.solution.provider/package.json
+++ b/exercises/06.honeypot/03.solution.provider/package.json
@@ -65,6 +65,7 @@
     "esbuild": "^0.19.5",
     "eslint": "^8.51.0",
     "eslint-config-prettier": "^9.0.0",
+    "execa": "^9.6.1",
     "fs-extra": "^11.1.1",
     "npm-run-all": "^4.1.5",
     "postcss": "^8.4.31",

--- a/exercises/06.honeypot/04.problem.seed/package.json
+++ b/exercises/06.honeypot/04.problem.seed/package.json
@@ -65,6 +65,7 @@
     "esbuild": "^0.19.5",
     "eslint": "^8.51.0",
     "eslint-config-prettier": "^9.0.0",
+    "execa": "^9.6.1",
     "fs-extra": "^11.1.1",
     "npm-run-all": "^4.1.5",
     "postcss": "^8.4.31",

--- a/exercises/06.honeypot/04.solution.seed/package.json
+++ b/exercises/06.honeypot/04.solution.seed/package.json
@@ -65,6 +65,7 @@
     "esbuild": "^0.19.5",
     "eslint": "^8.51.0",
     "eslint-config-prettier": "^9.0.0",
+    "execa": "^9.6.1",
     "fs-extra": "^11.1.1",
     "npm-run-all": "^4.1.5",
     "postcss": "^8.4.31",

--- a/exercises/07.csrf/01.problem.setup/package.json
+++ b/exercises/07.csrf/01.problem.setup/package.json
@@ -65,6 +65,7 @@
     "esbuild": "^0.19.5",
     "eslint": "^8.51.0",
     "eslint-config-prettier": "^9.0.0",
+    "execa": "^9.6.1",
     "fs-extra": "^11.1.1",
     "npm-run-all": "^4.1.5",
     "postcss": "^8.4.31",

--- a/exercises/07.csrf/01.solution.setup/package.json
+++ b/exercises/07.csrf/01.solution.setup/package.json
@@ -65,6 +65,7 @@
     "esbuild": "^0.19.5",
     "eslint": "^8.51.0",
     "eslint-config-prettier": "^9.0.0",
+    "execa": "^9.6.1",
     "fs-extra": "^11.1.1",
     "npm-run-all": "^4.1.5",
     "postcss": "^8.4.31",

--- a/exercises/07.csrf/02.problem.verification/package.json
+++ b/exercises/07.csrf/02.problem.verification/package.json
@@ -65,6 +65,7 @@
     "esbuild": "^0.19.5",
     "eslint": "^8.51.0",
     "eslint-config-prettier": "^9.0.0",
+    "execa": "^9.6.1",
     "fs-extra": "^11.1.1",
     "npm-run-all": "^4.1.5",
     "postcss": "^8.4.31",

--- a/exercises/07.csrf/02.solution.verification/package.json
+++ b/exercises/07.csrf/02.solution.verification/package.json
@@ -65,6 +65,7 @@
     "esbuild": "^0.19.5",
     "eslint": "^8.51.0",
     "eslint-config-prettier": "^9.0.0",
+    "execa": "^9.6.1",
     "fs-extra": "^11.1.1",
     "npm-run-all": "^4.1.5",
     "postcss": "^8.4.31",

--- a/exercises/08.rate-limiting/01.problem.basic/package.json
+++ b/exercises/08.rate-limiting/01.problem.basic/package.json
@@ -65,6 +65,7 @@
     "esbuild": "^0.19.5",
     "eslint": "^8.51.0",
     "eslint-config-prettier": "^9.0.0",
+    "execa": "^9.6.1",
     "fs-extra": "^11.1.1",
     "npm-run-all": "^4.1.5",
     "postcss": "^8.4.31",

--- a/exercises/08.rate-limiting/01.solution.basic/package.json
+++ b/exercises/08.rate-limiting/01.solution.basic/package.json
@@ -65,6 +65,7 @@
     "esbuild": "^0.19.5",
     "eslint": "^8.51.0",
     "eslint-config-prettier": "^9.0.0",
+    "execa": "^9.6.1",
     "fs-extra": "^11.1.1",
     "npm-run-all": "^4.1.5",
     "postcss": "^8.4.31",

--- a/exercises/08.rate-limiting/02.problem.tuned/package.json
+++ b/exercises/08.rate-limiting/02.problem.tuned/package.json
@@ -65,6 +65,7 @@
     "esbuild": "^0.19.5",
     "eslint": "^8.51.0",
     "eslint-config-prettier": "^9.0.0",
+    "execa": "^9.6.1",
     "fs-extra": "^11.1.1",
     "npm-run-all": "^4.1.5",
     "postcss": "^8.4.31",

--- a/exercises/08.rate-limiting/02.solution.tuned/package.json
+++ b/exercises/08.rate-limiting/02.solution.tuned/package.json
@@ -65,6 +65,7 @@
     "esbuild": "^0.19.5",
     "eslint": "^8.51.0",
     "eslint-config-prettier": "^9.0.0",
+    "execa": "^9.6.1",
     "fs-extra": "^11.1.1",
     "npm-run-all": "^4.1.5",
     "postcss": "^8.4.31",

--- a/package-lock.json
+++ b/package-lock.json
@@ -73,6 +73,7 @@
         "esbuild": "^0.19.5",
         "eslint": "^8.51.0",
         "eslint-config-prettier": "^9.0.0",
+        "execa": "^9.6.1",
         "fs-extra": "^11.1.1",
         "npm-run-all": "^4.1.5",
         "postcss": "^8.4.31",
@@ -145,6 +146,7 @@
         "esbuild": "^0.19.5",
         "eslint": "^8.51.0",
         "eslint-config-prettier": "^9.0.0",
+        "execa": "^9.6.1",
         "fs-extra": "^11.1.1",
         "npm-run-all": "^4.1.5",
         "postcss": "^8.4.31",
@@ -217,6 +219,7 @@
         "esbuild": "^0.19.5",
         "eslint": "^8.51.0",
         "eslint-config-prettier": "^9.0.0",
+        "execa": "^9.6.1",
         "fs-extra": "^11.1.1",
         "npm-run-all": "^4.1.5",
         "postcss": "^8.4.31",
@@ -289,6 +292,7 @@
         "esbuild": "^0.19.5",
         "eslint": "^8.51.0",
         "eslint-config-prettier": "^9.0.0",
+        "execa": "^9.6.1",
         "fs-extra": "^11.1.1",
         "npm-run-all": "^4.1.5",
         "postcss": "^8.4.31",
@@ -361,6 +365,7 @@
         "esbuild": "^0.19.5",
         "eslint": "^8.51.0",
         "eslint-config-prettier": "^9.0.0",
+        "execa": "^9.6.1",
         "fs-extra": "^11.1.1",
         "npm-run-all": "^4.1.5",
         "postcss": "^8.4.31",
@@ -433,6 +438,7 @@
         "esbuild": "^0.19.5",
         "eslint": "^8.51.0",
         "eslint-config-prettier": "^9.0.0",
+        "execa": "^9.6.1",
         "fs-extra": "^11.1.1",
         "npm-run-all": "^4.1.5",
         "postcss": "^8.4.31",
@@ -505,6 +511,7 @@
         "esbuild": "^0.19.5",
         "eslint": "^8.51.0",
         "eslint-config-prettier": "^9.0.0",
+        "execa": "^9.6.1",
         "fs-extra": "^11.1.1",
         "npm-run-all": "^4.1.5",
         "postcss": "^8.4.31",
@@ -577,6 +584,7 @@
         "esbuild": "^0.19.5",
         "eslint": "^8.51.0",
         "eslint-config-prettier": "^9.0.0",
+        "execa": "^9.6.1",
         "fs-extra": "^11.1.1",
         "npm-run-all": "^4.1.5",
         "postcss": "^8.4.31",
@@ -649,6 +657,7 @@
         "esbuild": "^0.19.5",
         "eslint": "^8.51.0",
         "eslint-config-prettier": "^9.0.0",
+        "execa": "^9.6.1",
         "fs-extra": "^11.1.1",
         "npm-run-all": "^4.1.5",
         "postcss": "^8.4.31",
@@ -721,6 +730,7 @@
         "esbuild": "^0.19.5",
         "eslint": "^8.51.0",
         "eslint-config-prettier": "^9.0.0",
+        "execa": "^9.6.1",
         "fs-extra": "^11.1.1",
         "npm-run-all": "^4.1.5",
         "postcss": "^8.4.31",
@@ -793,6 +803,7 @@
         "esbuild": "^0.19.5",
         "eslint": "^8.51.0",
         "eslint-config-prettier": "^9.0.0",
+        "execa": "^9.6.1",
         "fs-extra": "^11.1.1",
         "npm-run-all": "^4.1.5",
         "postcss": "^8.4.31",
@@ -865,6 +876,7 @@
         "esbuild": "^0.19.5",
         "eslint": "^8.51.0",
         "eslint-config-prettier": "^9.0.0",
+        "execa": "^9.6.1",
         "fs-extra": "^11.1.1",
         "npm-run-all": "^4.1.5",
         "postcss": "^8.4.31",
@@ -937,6 +949,7 @@
         "esbuild": "^0.19.5",
         "eslint": "^8.51.0",
         "eslint-config-prettier": "^9.0.0",
+        "execa": "^9.6.1",
         "fs-extra": "^11.1.1",
         "npm-run-all": "^4.1.5",
         "postcss": "^8.4.31",
@@ -1009,6 +1022,7 @@
         "esbuild": "^0.19.5",
         "eslint": "^8.51.0",
         "eslint-config-prettier": "^9.0.0",
+        "execa": "^9.6.1",
         "fs-extra": "^11.1.1",
         "npm-run-all": "^4.1.5",
         "postcss": "^8.4.31",
@@ -1081,6 +1095,7 @@
         "esbuild": "^0.19.5",
         "eslint": "^8.51.0",
         "eslint-config-prettier": "^9.0.0",
+        "execa": "^9.6.1",
         "fs-extra": "^11.1.1",
         "npm-run-all": "^4.1.5",
         "postcss": "^8.4.31",
@@ -1153,6 +1168,7 @@
         "esbuild": "^0.19.5",
         "eslint": "^8.51.0",
         "eslint-config-prettier": "^9.0.0",
+        "execa": "^9.6.1",
         "fs-extra": "^11.1.1",
         "npm-run-all": "^4.1.5",
         "postcss": "^8.4.31",
@@ -1225,6 +1241,7 @@
         "esbuild": "^0.19.5",
         "eslint": "^8.51.0",
         "eslint-config-prettier": "^9.0.0",
+        "execa": "^9.6.1",
         "fs-extra": "^11.1.1",
         "npm-run-all": "^4.1.5",
         "postcss": "^8.4.31",
@@ -1297,6 +1314,7 @@
         "esbuild": "^0.19.5",
         "eslint": "^8.51.0",
         "eslint-config-prettier": "^9.0.0",
+        "execa": "^9.6.1",
         "fs-extra": "^11.1.1",
         "npm-run-all": "^4.1.5",
         "postcss": "^8.4.31",
@@ -1369,6 +1387,7 @@
         "esbuild": "^0.19.5",
         "eslint": "^8.51.0",
         "eslint-config-prettier": "^9.0.0",
+        "execa": "^9.6.1",
         "fs-extra": "^11.1.1",
         "npm-run-all": "^4.1.5",
         "postcss": "^8.4.31",
@@ -1441,6 +1460,7 @@
         "esbuild": "^0.19.5",
         "eslint": "^8.51.0",
         "eslint-config-prettier": "^9.0.0",
+        "execa": "^9.6.1",
         "fs-extra": "^11.1.1",
         "npm-run-all": "^4.1.5",
         "postcss": "^8.4.31",
@@ -1513,6 +1533,7 @@
         "esbuild": "^0.19.5",
         "eslint": "^8.51.0",
         "eslint-config-prettier": "^9.0.0",
+        "execa": "^9.6.1",
         "fs-extra": "^11.1.1",
         "npm-run-all": "^4.1.5",
         "postcss": "^8.4.31",
@@ -1585,6 +1606,7 @@
         "esbuild": "^0.19.5",
         "eslint": "^8.51.0",
         "eslint-config-prettier": "^9.0.0",
+        "execa": "^9.6.1",
         "fs-extra": "^11.1.1",
         "npm-run-all": "^4.1.5",
         "postcss": "^8.4.31",
@@ -1657,6 +1679,7 @@
         "esbuild": "^0.19.5",
         "eslint": "^8.51.0",
         "eslint-config-prettier": "^9.0.0",
+        "execa": "^9.6.1",
         "fs-extra": "^11.1.1",
         "npm-run-all": "^4.1.5",
         "postcss": "^8.4.31",
@@ -1729,6 +1752,7 @@
         "esbuild": "^0.19.5",
         "eslint": "^8.51.0",
         "eslint-config-prettier": "^9.0.0",
+        "execa": "^9.6.1",
         "fs-extra": "^11.1.1",
         "npm-run-all": "^4.1.5",
         "postcss": "^8.4.31",
@@ -1801,6 +1825,7 @@
         "esbuild": "^0.19.5",
         "eslint": "^8.51.0",
         "eslint-config-prettier": "^9.0.0",
+        "execa": "^9.6.1",
         "fs-extra": "^11.1.1",
         "npm-run-all": "^4.1.5",
         "postcss": "^8.4.31",
@@ -1873,6 +1898,7 @@
         "esbuild": "^0.19.5",
         "eslint": "^8.51.0",
         "eslint-config-prettier": "^9.0.0",
+        "execa": "^9.6.1",
         "fs-extra": "^11.1.1",
         "npm-run-all": "^4.1.5",
         "postcss": "^8.4.31",
@@ -1945,6 +1971,7 @@
         "esbuild": "^0.19.5",
         "eslint": "^8.51.0",
         "eslint-config-prettier": "^9.0.0",
+        "execa": "^9.6.1",
         "fs-extra": "^11.1.1",
         "npm-run-all": "^4.1.5",
         "postcss": "^8.4.31",
@@ -2017,6 +2044,7 @@
         "esbuild": "^0.19.5",
         "eslint": "^8.51.0",
         "eslint-config-prettier": "^9.0.0",
+        "execa": "^9.6.1",
         "fs-extra": "^11.1.1",
         "npm-run-all": "^4.1.5",
         "postcss": "^8.4.31",
@@ -2089,6 +2117,7 @@
         "esbuild": "^0.19.5",
         "eslint": "^8.51.0",
         "eslint-config-prettier": "^9.0.0",
+        "execa": "^9.6.1",
         "fs-extra": "^11.1.1",
         "npm-run-all": "^4.1.5",
         "postcss": "^8.4.31",
@@ -2161,6 +2190,7 @@
         "esbuild": "^0.19.5",
         "eslint": "^8.51.0",
         "eslint-config-prettier": "^9.0.0",
+        "execa": "^9.6.1",
         "fs-extra": "^11.1.1",
         "npm-run-all": "^4.1.5",
         "postcss": "^8.4.31",
@@ -2233,6 +2263,7 @@
         "esbuild": "^0.19.5",
         "eslint": "^8.51.0",
         "eslint-config-prettier": "^9.0.0",
+        "execa": "^9.6.1",
         "fs-extra": "^11.1.1",
         "npm-run-all": "^4.1.5",
         "postcss": "^8.4.31",
@@ -2305,6 +2336,7 @@
         "esbuild": "^0.19.5",
         "eslint": "^8.51.0",
         "eslint-config-prettier": "^9.0.0",
+        "execa": "^9.6.1",
         "fs-extra": "^11.1.1",
         "npm-run-all": "^4.1.5",
         "postcss": "^8.4.31",
@@ -2377,6 +2409,7 @@
         "esbuild": "^0.19.5",
         "eslint": "^8.51.0",
         "eslint-config-prettier": "^9.0.0",
+        "execa": "^9.6.1",
         "fs-extra": "^11.1.1",
         "npm-run-all": "^4.1.5",
         "postcss": "^8.4.31",
@@ -2449,6 +2482,7 @@
         "esbuild": "^0.19.5",
         "eslint": "^8.51.0",
         "eslint-config-prettier": "^9.0.0",
+        "execa": "^9.6.1",
         "fs-extra": "^11.1.1",
         "npm-run-all": "^4.1.5",
         "postcss": "^8.4.31",
@@ -2521,6 +2555,7 @@
         "esbuild": "^0.19.5",
         "eslint": "^8.51.0",
         "eslint-config-prettier": "^9.0.0",
+        "execa": "^9.6.1",
         "fs-extra": "^11.1.1",
         "npm-run-all": "^4.1.5",
         "postcss": "^8.4.31",
@@ -2593,6 +2628,7 @@
         "esbuild": "^0.19.5",
         "eslint": "^8.51.0",
         "eslint-config-prettier": "^9.0.0",
+        "execa": "^9.6.1",
         "fs-extra": "^11.1.1",
         "npm-run-all": "^4.1.5",
         "postcss": "^8.4.31",
@@ -2665,6 +2701,7 @@
         "esbuild": "^0.19.5",
         "eslint": "^8.51.0",
         "eslint-config-prettier": "^9.0.0",
+        "execa": "^9.6.1",
         "fs-extra": "^11.1.1",
         "npm-run-all": "^4.1.5",
         "postcss": "^8.4.31",
@@ -2737,6 +2774,7 @@
         "esbuild": "^0.19.5",
         "eslint": "^8.51.0",
         "eslint-config-prettier": "^9.0.0",
+        "execa": "^9.6.1",
         "fs-extra": "^11.1.1",
         "npm-run-all": "^4.1.5",
         "postcss": "^8.4.31",
@@ -2809,6 +2847,7 @@
         "esbuild": "^0.19.5",
         "eslint": "^8.51.0",
         "eslint-config-prettier": "^9.0.0",
+        "execa": "^9.6.1",
         "fs-extra": "^11.1.1",
         "npm-run-all": "^4.1.5",
         "postcss": "^8.4.31",
@@ -2881,6 +2920,7 @@
         "esbuild": "^0.19.5",
         "eslint": "^8.51.0",
         "eslint-config-prettier": "^9.0.0",
+        "execa": "^9.6.1",
         "fs-extra": "^11.1.1",
         "npm-run-all": "^4.1.5",
         "postcss": "^8.4.31",
@@ -2953,6 +2993,7 @@
         "esbuild": "^0.19.5",
         "eslint": "^8.51.0",
         "eslint-config-prettier": "^9.0.0",
+        "execa": "^9.6.1",
         "fs-extra": "^11.1.1",
         "npm-run-all": "^4.1.5",
         "postcss": "^8.4.31",
@@ -3025,6 +3066,7 @@
         "esbuild": "^0.19.5",
         "eslint": "^8.51.0",
         "eslint-config-prettier": "^9.0.0",
+        "execa": "^9.6.1",
         "fs-extra": "^11.1.1",
         "npm-run-all": "^4.1.5",
         "postcss": "^8.4.31",
@@ -3097,6 +3139,7 @@
         "esbuild": "^0.19.5",
         "eslint": "^8.51.0",
         "eslint-config-prettier": "^9.0.0",
+        "execa": "^9.6.1",
         "fs-extra": "^11.1.1",
         "npm-run-all": "^4.1.5",
         "postcss": "^8.4.31",
@@ -3169,6 +3212,7 @@
         "esbuild": "^0.19.5",
         "eslint": "^8.51.0",
         "eslint-config-prettier": "^9.0.0",
+        "execa": "^9.6.1",
         "fs-extra": "^11.1.1",
         "npm-run-all": "^4.1.5",
         "postcss": "^8.4.31",
@@ -7244,6 +7288,26 @@
       "integrity": "sha512-hw437iINopmQuxWPSUEvqE56NCPsiU8N4AYtfHmJFckclktzK9YQJieD3XkDCDH4OjL+C7zgPUh73R/nrcHrqw==",
       "dev": true
     },
+    "node_modules/@sec-ant/readable-stream": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@sec-ant/readable-stream/-/readable-stream-0.4.1.tgz",
+      "integrity": "sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@sindresorhus/merge-streams": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-4.0.0.tgz",
+      "integrity": "sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/@total-typescript/ts-reset": {
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/@total-typescript/ts-reset/-/ts-reset-0.5.1.tgz",
@@ -10358,6 +10422,75 @@
         "node": ">=6"
       }
     },
+    "node_modules/execa": {
+      "version": "9.6.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-9.6.1.tgz",
+      "integrity": "sha512-9Be3ZoN4LmYR90tUoVu2te2BsbzHfhJyfEiAVfz7N5/zv+jduIfLrV2xdQXOHbaD6KgpGdO9PRPM1Y4Q9QkPkA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sindresorhus/merge-streams": "^4.0.0",
+        "cross-spawn": "^7.0.6",
+        "figures": "^6.1.0",
+        "get-stream": "^9.0.0",
+        "human-signals": "^8.0.1",
+        "is-plain-obj": "^4.1.0",
+        "is-stream": "^4.0.1",
+        "npm-run-path": "^6.0.0",
+        "pretty-ms": "^9.2.0",
+        "signal-exit": "^4.1.0",
+        "strip-final-newline": "^4.0.0",
+        "yoctocolors": "^2.1.1"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.5.0"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/execa/node_modules/is-plain-obj": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/execa/node_modules/parse-ms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-4.0.0.tgz",
+      "integrity": "sha512-TXfryirbmq34y8QBwgqCVLi+8oA3oWx2eAnSn62ITyEhEYaWRlVZ2DvMM9eZbMs/RfxPu/PK/aBLyGj4IrqMHw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/execa/node_modules/pretty-ms": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-9.3.0.tgz",
+      "integrity": "sha512-gjVS5hOP+M3wMm5nmNOucbIrqudzs9v/57bWRHQWLYklXqoXKrVfYW2W9+glfGsqtPgpiz5WwyEEB+ksXIx3gQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "parse-ms": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/exercises__sep__01.form-validation__sep__01.problem.form-validation": {
       "resolved": "exercises/01.form-validation/01.problem.form-validation",
       "link": true
@@ -10718,6 +10851,35 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/figures": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-6.1.0.tgz",
+      "integrity": "sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-unicode-supported": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/figures/node_modules/is-unicode-supported": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-2.1.0.tgz",
+      "integrity": "sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/file-entry-cache": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
@@ -11013,6 +11175,23 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/get-stream": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-9.0.1.tgz",
+      "integrity": "sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sec-ant/readable-stream": "^0.4.1",
+        "is-stream": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/get-symbol-description": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.0.2.tgz",
@@ -11289,6 +11468,16 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/human-signals": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-8.0.1.tgz",
+      "integrity": "sha512-eKCa6bwnJhvxj14kZk5NCPc6Hb6BdsU9DZcOnmQKSnO1VKrfV0zCvtttPZUsBvjmNDn8rpcJfpwSYnHBjc95MQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18.0"
       }
     },
     "node_modules/iconv-lite": {
@@ -11806,6 +11995,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-stream": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-4.0.1.tgz",
+      "integrity": "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-string": {
@@ -13367,6 +13569,36 @@
       },
       "bin": {
         "which": "bin/which"
+      }
+    },
+    "node_modules/npm-run-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-6.0.0.tgz",
+      "integrity": "sha512-9qny7Z9DsQU8Ou39ERsPU4OZQlSTP47ShQzuKZ6PRXpYLtIFgl/DEBYEXKlvcEa+9tHVcK8CF81Y2V72qaZhWA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^4.0.0",
+        "unicorn-magic": "^0.3.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/npm-run-path/node_modules/path-key": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+      "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/object-assign": {
@@ -15793,6 +16025,19 @@
         "node": ">=4"
       }
     },
+    "node_modules/strip-final-newline": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-4.0.0.tgz",
+      "integrity": "sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/strip-json-comments": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
@@ -16355,6 +16600,19 @@
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
       "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
       "devOptional": true
+    },
+    "node_modules/unicorn-magic": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.3.0.tgz",
+      "integrity": "sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/unique-filename": {
       "version": "3.0.0",
@@ -17350,6 +17608,19 @@
       "dev": true,
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/yoctocolors": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/yoctocolors/-/yoctocolors-2.1.2.tgz",
+      "integrity": "sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"


### PR DESCRIPTION
Add `execa` as a `devDependency` to all exercise apps to resolve `ERR_MODULE_NOT_FOUND` when running `server/dev-server.js`.

The `server/dev-server.js` files in the exercise apps import `execa`, but `execa` was not declared as a dependency in their `package.json` files. This issue was likely masked in older setups where `execa` was accidentally available at the root `node_modules`. With current dependency resolution, `execa` was only found nested under other packages, making it unresolvable from the playground apps, leading to crashes.

---
<p><a href="https://cursor.com/agents?id=bc-8dde6294-d774-480e-8a0b-811337861b85"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8dde6294-d774-480e-8a0b-811337861b85"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency-only change (dev-only) with no runtime or business-logic modifications; primary risk is minor lockfile/install churn.
> 
> **Overview**
> Fixes local dev crashes in the exercise apps by explicitly adding `execa` as a `devDependency` to each exercise `package.json`, matching what `server/dev-server.js` already imports.
> 
> Updates `package-lock.json` to include `execa@^9.6.1` and its transitive dependencies so installs resolve consistently.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7c6617b79f1182b60dd295830eea8f25bd454ac3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->