### PR TITLE
Handle unmatched mutation requests as 404s

### DIFF
--- a/exercises/01.form-validation/01.problem.form-validation/app/routes/$.tsx
+++ b/exercises/01.form-validation/01.problem.form-validation/app/routes/$.tsx
@@ -12,6 +12,10 @@ export async function loader() {
 	throw new Response('Not found', { status: 404 })
 }
 
+export async function action() {
+	throw new Response('Not found', { status: 404 })
+}
+
 export default function NotFound() {
 	// due to the loader, this component will never be rendered, but we'll return
 	// the error boundary just in case.

--- a/exercises/01.form-validation/01.problem.form-validation/tests/e2e/smoke.test.ts
+++ b/exercises/01.form-validation/01.problem.form-validation/tests/e2e/smoke.test.ts
@@ -6,3 +6,8 @@ test('can visit the home page', async ({ page }) => {
 
 	// TODO: figure out how to assert the favicon was loaded
 })
+
+test('returns 404 for POST requests to unmatched routes', async ({ request }) => {
+	const response = await request.post('/connectors/resource/index.php')
+	expect(response.status()).toBe(404)
+})

--- a/exercises/01.form-validation/01.problem.form-validation/tests/e2e/smoke.test.ts
+++ b/exercises/01.form-validation/01.problem.form-validation/tests/e2e/smoke.test.ts
@@ -2,7 +2,7 @@ import { test, expect } from '@playwright/test'
 
 test('can visit the home page', async ({ page }) => {
 	await page.goto('/')
-	await expect(page.getByText('Hello World')).toBeVisible()
+	await expect(page.getByRole('heading', { name: 'Epic Notes' })).toBeVisible()
 
 	// TODO: figure out how to assert the favicon was loaded
 })

--- a/exercises/01.form-validation/01.solution.form-validation/app/routes/$.tsx
+++ b/exercises/01.form-validation/01.solution.form-validation/app/routes/$.tsx
@@ -12,6 +12,10 @@ export async function loader() {
 	throw new Response('Not found', { status: 404 })
 }
 
+export async function action() {
+	throw new Response('Not found', { status: 404 })
+}
+
 export default function NotFound() {
 	// due to the loader, this component will never be rendered, but we'll return
 	// the error boundary just in case.

--- a/exercises/01.form-validation/01.solution.form-validation/tests/e2e/smoke.test.ts
+++ b/exercises/01.form-validation/01.solution.form-validation/tests/e2e/smoke.test.ts
@@ -6,3 +6,8 @@ test('can visit the home page', async ({ page }) => {
 
 	// TODO: figure out how to assert the favicon was loaded
 })
+
+test('returns 404 for POST requests to unmatched routes', async ({ request }) => {
+	const response = await request.post('/connectors/resource/index.php')
+	expect(response.status()).toBe(404)
+})

--- a/exercises/01.form-validation/01.solution.form-validation/tests/e2e/smoke.test.ts
+++ b/exercises/01.form-validation/01.solution.form-validation/tests/e2e/smoke.test.ts
@@ -2,7 +2,7 @@ import { test, expect } from '@playwright/test'
 
 test('can visit the home page', async ({ page }) => {
 	await page.goto('/')
-	await expect(page.getByText('Hello World')).toBeVisible()
+	await expect(page.getByRole('heading', { name: 'Epic Notes' })).toBeVisible()
 
 	// TODO: figure out how to assert the favicon was loaded
 })

--- a/exercises/01.form-validation/02.problem.server-validation/app/routes/$.tsx
+++ b/exercises/01.form-validation/02.problem.server-validation/app/routes/$.tsx
@@ -12,6 +12,10 @@ export async function loader() {
 	throw new Response('Not found', { status: 404 })
 }
 
+export async function action() {
+	throw new Response('Not found', { status: 404 })
+}
+
 export default function NotFound() {
 	// due to the loader, this component will never be rendered, but we'll return
 	// the error boundary just in case.

--- a/exercises/01.form-validation/02.problem.server-validation/tests/e2e/smoke.test.ts
+++ b/exercises/01.form-validation/02.problem.server-validation/tests/e2e/smoke.test.ts
@@ -6,3 +6,8 @@ test('can visit the home page', async ({ page }) => {
 
 	// TODO: figure out how to assert the favicon was loaded
 })
+
+test('returns 404 for POST requests to unmatched routes', async ({ request }) => {
+	const response = await request.post('/connectors/resource/index.php')
+	expect(response.status()).toBe(404)
+})

--- a/exercises/01.form-validation/02.problem.server-validation/tests/e2e/smoke.test.ts
+++ b/exercises/01.form-validation/02.problem.server-validation/tests/e2e/smoke.test.ts
@@ -2,7 +2,7 @@ import { test, expect } from '@playwright/test'
 
 test('can visit the home page', async ({ page }) => {
 	await page.goto('/')
-	await expect(page.getByText('Hello World')).toBeVisible()
+	await expect(page.getByRole('heading', { name: 'Epic Notes' })).toBeVisible()
 
 	// TODO: figure out how to assert the favicon was loaded
 })

--- a/exercises/01.form-validation/02.solution.server-validation/app/routes/$.tsx
+++ b/exercises/01.form-validation/02.solution.server-validation/app/routes/$.tsx
@@ -12,6 +12,10 @@ export async function loader() {
 	throw new Response('Not found', { status: 404 })
 }
 
+export async function action() {
+	throw new Response('Not found', { status: 404 })
+}
+
 export default function NotFound() {
 	// due to the loader, this component will never be rendered, but we'll return
 	// the error boundary just in case.

--- a/exercises/01.form-validation/02.solution.server-validation/tests/e2e/smoke.test.ts
+++ b/exercises/01.form-validation/02.solution.server-validation/tests/e2e/smoke.test.ts
@@ -6,3 +6,8 @@ test('can visit the home page', async ({ page }) => {
 
 	// TODO: figure out how to assert the favicon was loaded
 })
+
+test('returns 404 for POST requests to unmatched routes', async ({ request }) => {
+	const response = await request.post('/connectors/resource/index.php')
+	expect(response.status()).toBe(404)
+})

--- a/exercises/01.form-validation/02.solution.server-validation/tests/e2e/smoke.test.ts
+++ b/exercises/01.form-validation/02.solution.server-validation/tests/e2e/smoke.test.ts
@@ -2,7 +2,7 @@ import { test, expect } from '@playwright/test'
 
 test('can visit the home page', async ({ page }) => {
 	await page.goto('/')
-	await expect(page.getByText('Hello World')).toBeVisible()
+	await expect(page.getByRole('heading', { name: 'Epic Notes' })).toBeVisible()
 
 	// TODO: figure out how to assert the favicon was loaded
 })

--- a/exercises/01.form-validation/03.problem.no-validate/app/routes/$.tsx
+++ b/exercises/01.form-validation/03.problem.no-validate/app/routes/$.tsx
@@ -12,6 +12,10 @@ export async function loader() {
 	throw new Response('Not found', { status: 404 })
 }
 
+export async function action() {
+	throw new Response('Not found', { status: 404 })
+}
+
 export default function NotFound() {
 	// due to the loader, this component will never be rendered, but we'll return
 	// the error boundary just in case.

--- a/exercises/01.form-validation/03.problem.no-validate/tests/e2e/smoke.test.ts
+++ b/exercises/01.form-validation/03.problem.no-validate/tests/e2e/smoke.test.ts
@@ -6,3 +6,8 @@ test('can visit the home page', async ({ page }) => {
 
 	// TODO: figure out how to assert the favicon was loaded
 })
+
+test('returns 404 for POST requests to unmatched routes', async ({ request }) => {
+	const response = await request.post('/connectors/resource/index.php')
+	expect(response.status()).toBe(404)
+})

--- a/exercises/01.form-validation/03.problem.no-validate/tests/e2e/smoke.test.ts
+++ b/exercises/01.form-validation/03.problem.no-validate/tests/e2e/smoke.test.ts
@@ -2,7 +2,7 @@ import { test, expect } from '@playwright/test'
 
 test('can visit the home page', async ({ page }) => {
 	await page.goto('/')
-	await expect(page.getByText('Hello World')).toBeVisible()
+	await expect(page.getByRole('heading', { name: 'Epic Notes' })).toBeVisible()
 
 	// TODO: figure out how to assert the favicon was loaded
 })

--- a/exercises/01.form-validation/03.solution.no-validate/app/routes/$.tsx
+++ b/exercises/01.form-validation/03.solution.no-validate/app/routes/$.tsx
@@ -12,6 +12,10 @@ export async function loader() {
 	throw new Response('Not found', { status: 404 })
 }
 
+export async function action() {
+	throw new Response('Not found', { status: 404 })
+}
+
 export default function NotFound() {
 	// due to the loader, this component will never be rendered, but we'll return
 	// the error boundary just in case.

--- a/exercises/01.form-validation/03.solution.no-validate/tests/e2e/smoke.test.ts
+++ b/exercises/01.form-validation/03.solution.no-validate/tests/e2e/smoke.test.ts
@@ -6,3 +6,8 @@ test('can visit the home page', async ({ page }) => {
 
 	// TODO: figure out how to assert the favicon was loaded
 })
+
+test('returns 404 for POST requests to unmatched routes', async ({ request }) => {
+	const response = await request.post('/connectors/resource/index.php')
+	expect(response.status()).toBe(404)
+})

--- a/exercises/01.form-validation/03.solution.no-validate/tests/e2e/smoke.test.ts
+++ b/exercises/01.form-validation/03.solution.no-validate/tests/e2e/smoke.test.ts
@@ -2,7 +2,7 @@ import { test, expect } from '@playwright/test'
 
 test('can visit the home page', async ({ page }) => {
 	await page.goto('/')
-	await expect(page.getByText('Hello World')).toBeVisible()
+	await expect(page.getByRole('heading', { name: 'Epic Notes' })).toBeVisible()
 
 	// TODO: figure out how to assert the favicon was loaded
 })

--- a/exercises/02.accessibility/01.problem.labels/app/routes/$.tsx
+++ b/exercises/02.accessibility/01.problem.labels/app/routes/$.tsx
@@ -12,6 +12,10 @@ export async function loader() {
 	throw new Response('Not found', { status: 404 })
 }
 
+export async function action() {
+	throw new Response('Not found', { status: 404 })
+}
+
 export default function NotFound() {
 	// due to the loader, this component will never be rendered, but we'll return
 	// the error boundary just in case.

--- a/exercises/02.accessibility/01.problem.labels/tests/e2e/smoke.test.ts
+++ b/exercises/02.accessibility/01.problem.labels/tests/e2e/smoke.test.ts
@@ -6,3 +6,8 @@ test('can visit the home page', async ({ page }) => {
 
 	// TODO: figure out how to assert the favicon was loaded
 })
+
+test('returns 404 for POST requests to unmatched routes', async ({ request }) => {
+	const response = await request.post('/connectors/resource/index.php')
+	expect(response.status()).toBe(404)
+})

--- a/exercises/02.accessibility/01.problem.labels/tests/e2e/smoke.test.ts
+++ b/exercises/02.accessibility/01.problem.labels/tests/e2e/smoke.test.ts
@@ -2,7 +2,7 @@ import { test, expect } from '@playwright/test'
 
 test('can visit the home page', async ({ page }) => {
 	await page.goto('/')
-	await expect(page.getByText('Hello World')).toBeVisible()
+	await expect(page.getByRole('heading', { name: 'Epic Notes' })).toBeVisible()
 
 	// TODO: figure out how to assert the favicon was loaded
 })

--- a/exercises/02.accessibility/01.solution.labels/app/routes/$.tsx
+++ b/exercises/02.accessibility/01.solution.labels/app/routes/$.tsx
@@ -12,6 +12,10 @@ export async function loader() {
 	throw new Response('Not found', { status: 404 })
 }
 
+export async function action() {
+	throw new Response('Not found', { status: 404 })
+}
+
 export default function NotFound() {
 	// due to the loader, this component will never be rendered, but we'll return
 	// the error boundary just in case.

--- a/exercises/02.accessibility/01.solution.labels/tests/e2e/smoke.test.ts
+++ b/exercises/02.accessibility/01.solution.labels/tests/e2e/smoke.test.ts
@@ -6,3 +6,8 @@ test('can visit the home page', async ({ page }) => {
 
 	// TODO: figure out how to assert the favicon was loaded
 })
+
+test('returns 404 for POST requests to unmatched routes', async ({ request }) => {
+	const response = await request.post('/connectors/resource/index.php')
+	expect(response.status()).toBe(404)
+})

--- a/exercises/02.accessibility/01.solution.labels/tests/e2e/smoke.test.ts
+++ b/exercises/02.accessibility/01.solution.labels/tests/e2e/smoke.test.ts
@@ -2,7 +2,7 @@ import { test, expect } from '@playwright/test'
 
 test('can visit the home page', async ({ page }) => {
 	await page.goto('/')
-	await expect(page.getByText('Hello World')).toBeVisible()
+	await expect(page.getByRole('heading', { name: 'Epic Notes' })).toBeVisible()
 
 	// TODO: figure out how to assert the favicon was loaded
 })

--- a/exercises/02.accessibility/02.problem.aria/app/routes/$.tsx
+++ b/exercises/02.accessibility/02.problem.aria/app/routes/$.tsx
@@ -12,6 +12,10 @@ export async function loader() {
 	throw new Response('Not found', { status: 404 })
 }
 
+export async function action() {
+	throw new Response('Not found', { status: 404 })
+}
+
 export default function NotFound() {
 	// due to the loader, this component will never be rendered, but we'll return
 	// the error boundary just in case.

--- a/exercises/02.accessibility/02.problem.aria/tests/e2e/smoke.test.ts
+++ b/exercises/02.accessibility/02.problem.aria/tests/e2e/smoke.test.ts
@@ -6,3 +6,8 @@ test('can visit the home page', async ({ page }) => {
 
 	// TODO: figure out how to assert the favicon was loaded
 })
+
+test('returns 404 for POST requests to unmatched routes', async ({ request }) => {
+	const response = await request.post('/connectors/resource/index.php')
+	expect(response.status()).toBe(404)
+})

--- a/exercises/02.accessibility/02.problem.aria/tests/e2e/smoke.test.ts
+++ b/exercises/02.accessibility/02.problem.aria/tests/e2e/smoke.test.ts
@@ -2,7 +2,7 @@ import { test, expect } from '@playwright/test'
 
 test('can visit the home page', async ({ page }) => {
 	await page.goto('/')
-	await expect(page.getByText('Hello World')).toBeVisible()
+	await expect(page.getByRole('heading', { name: 'Epic Notes' })).toBeVisible()
 
 	// TODO: figure out how to assert the favicon was loaded
 })

--- a/exercises/02.accessibility/02.solution.aria/app/routes/$.tsx
+++ b/exercises/02.accessibility/02.solution.aria/app/routes/$.tsx
@@ -12,6 +12,10 @@ export async function loader() {
 	throw new Response('Not found', { status: 404 })
 }
 
+export async function action() {
+	throw new Response('Not found', { status: 404 })
+}
+
 export default function NotFound() {
 	// due to the loader, this component will never be rendered, but we'll return
 	// the error boundary just in case.

--- a/exercises/02.accessibility/02.solution.aria/tests/e2e/smoke.test.ts
+++ b/exercises/02.accessibility/02.solution.aria/tests/e2e/smoke.test.ts
@@ -6,3 +6,8 @@ test('can visit the home page', async ({ page }) => {
 
 	// TODO: figure out how to assert the favicon was loaded
 })
+
+test('returns 404 for POST requests to unmatched routes', async ({ request }) => {
+	const response = await request.post('/connectors/resource/index.php')
+	expect(response.status()).toBe(404)
+})

--- a/exercises/02.accessibility/02.solution.aria/tests/e2e/smoke.test.ts
+++ b/exercises/02.accessibility/02.solution.aria/tests/e2e/smoke.test.ts
@@ -2,7 +2,7 @@ import { test, expect } from '@playwright/test'
 
 test('can visit the home page', async ({ page }) => {
 	await page.goto('/')
-	await expect(page.getByText('Hello World')).toBeVisible()
+	await expect(page.getByRole('heading', { name: 'Epic Notes' })).toBeVisible()
 
 	// TODO: figure out how to assert the favicon was loaded
 })

--- a/exercises/02.accessibility/03.problem.focus/app/routes/$.tsx
+++ b/exercises/02.accessibility/03.problem.focus/app/routes/$.tsx
@@ -12,6 +12,10 @@ export async function loader() {
 	throw new Response('Not found', { status: 404 })
 }
 
+export async function action() {
+	throw new Response('Not found', { status: 404 })
+}
+
 export default function NotFound() {
 	// due to the loader, this component will never be rendered, but we'll return
 	// the error boundary just in case.

--- a/exercises/02.accessibility/03.problem.focus/tests/e2e/smoke.test.ts
+++ b/exercises/02.accessibility/03.problem.focus/tests/e2e/smoke.test.ts
@@ -6,3 +6,8 @@ test('can visit the home page', async ({ page }) => {
 
 	// TODO: figure out how to assert the favicon was loaded
 })
+
+test('returns 404 for POST requests to unmatched routes', async ({ request }) => {
+	const response = await request.post('/connectors/resource/index.php')
+	expect(response.status()).toBe(404)
+})

--- a/exercises/02.accessibility/03.problem.focus/tests/e2e/smoke.test.ts
+++ b/exercises/02.accessibility/03.problem.focus/tests/e2e/smoke.test.ts
@@ -2,7 +2,7 @@ import { test, expect } from '@playwright/test'
 
 test('can visit the home page', async ({ page }) => {
 	await page.goto('/')
-	await expect(page.getByText('Hello World')).toBeVisible()
+	await expect(page.getByRole('heading', { name: 'Epic Notes' })).toBeVisible()
 
 	// TODO: figure out how to assert the favicon was loaded
 })

--- a/exercises/02.accessibility/03.solution.focus/app/routes/$.tsx
+++ b/exercises/02.accessibility/03.solution.focus/app/routes/$.tsx
@@ -12,6 +12,10 @@ export async function loader() {
 	throw new Response('Not found', { status: 404 })
 }
 
+export async function action() {
+	throw new Response('Not found', { status: 404 })
+}
+
 export default function NotFound() {
 	// due to the loader, this component will never be rendered, but we'll return
 	// the error boundary just in case.

--- a/exercises/02.accessibility/03.solution.focus/tests/e2e/smoke.test.ts
+++ b/exercises/02.accessibility/03.solution.focus/tests/e2e/smoke.test.ts
@@ -6,3 +6,8 @@ test('can visit the home page', async ({ page }) => {
 
 	// TODO: figure out how to assert the favicon was loaded
 })
+
+test('returns 404 for POST requests to unmatched routes', async ({ request }) => {
+	const response = await request.post('/connectors/resource/index.php')
+	expect(response.status()).toBe(404)
+})

--- a/exercises/02.accessibility/03.solution.focus/tests/e2e/smoke.test.ts
+++ b/exercises/02.accessibility/03.solution.focus/tests/e2e/smoke.test.ts
@@ -2,7 +2,7 @@ import { test, expect } from '@playwright/test'
 
 test('can visit the home page', async ({ page }) => {
 	await page.goto('/')
-	await expect(page.getByText('Hello World')).toBeVisible()
+	await expect(page.getByRole('heading', { name: 'Epic Notes' })).toBeVisible()
 
 	// TODO: figure out how to assert the favicon was loaded
 })

--- a/exercises/03.schema-validation/01.problem.zod/app/routes/$.tsx
+++ b/exercises/03.schema-validation/01.problem.zod/app/routes/$.tsx
@@ -12,6 +12,10 @@ export async function loader() {
 	throw new Response('Not found', { status: 404 })
 }
 
+export async function action() {
+	throw new Response('Not found', { status: 404 })
+}
+
 export default function NotFound() {
 	// due to the loader, this component will never be rendered, but we'll return
 	// the error boundary just in case.

--- a/exercises/03.schema-validation/01.problem.zod/tests/e2e/smoke.test.ts
+++ b/exercises/03.schema-validation/01.problem.zod/tests/e2e/smoke.test.ts
@@ -6,3 +6,8 @@ test('can visit the home page', async ({ page }) => {
 
 	// TODO: figure out how to assert the favicon was loaded
 })
+
+test('returns 404 for POST requests to unmatched routes', async ({ request }) => {
+	const response = await request.post('/connectors/resource/index.php')
+	expect(response.status()).toBe(404)
+})

--- a/exercises/03.schema-validation/01.problem.zod/tests/e2e/smoke.test.ts
+++ b/exercises/03.schema-validation/01.problem.zod/tests/e2e/smoke.test.ts
@@ -2,7 +2,7 @@ import { test, expect } from '@playwright/test'
 
 test('can visit the home page', async ({ page }) => {
 	await page.goto('/')
-	await expect(page.getByText('Hello World')).toBeVisible()
+	await expect(page.getByRole('heading', { name: 'Epic Notes' })).toBeVisible()
 
 	// TODO: figure out how to assert the favicon was loaded
 })

--- a/exercises/03.schema-validation/01.solution.zod/app/routes/$.tsx
+++ b/exercises/03.schema-validation/01.solution.zod/app/routes/$.tsx
@@ -12,6 +12,10 @@ export async function loader() {
 	throw new Response('Not found', { status: 404 })
 }
 
+export async function action() {
+	throw new Response('Not found', { status: 404 })
+}
+
 export default function NotFound() {
 	// due to the loader, this component will never be rendered, but we'll return
 	// the error boundary just in case.

--- a/exercises/03.schema-validation/01.solution.zod/tests/e2e/smoke.test.ts
+++ b/exercises/03.schema-validation/01.solution.zod/tests/e2e/smoke.test.ts
@@ -6,3 +6,8 @@ test('can visit the home page', async ({ page }) => {
 
 	// TODO: figure out how to assert the favicon was loaded
 })
+
+test('returns 404 for POST requests to unmatched routes', async ({ request }) => {
+	const response = await request.post('/connectors/resource/index.php')
+	expect(response.status()).toBe(404)
+})

--- a/exercises/03.schema-validation/01.solution.zod/tests/e2e/smoke.test.ts
+++ b/exercises/03.schema-validation/01.solution.zod/tests/e2e/smoke.test.ts
@@ -2,7 +2,7 @@ import { test, expect } from '@playwright/test'
 
 test('can visit the home page', async ({ page }) => {
 	await page.goto('/')
-	await expect(page.getByText('Hello World')).toBeVisible()
+	await expect(page.getByRole('heading', { name: 'Epic Notes' })).toBeVisible()
 
 	// TODO: figure out how to assert the favicon was loaded
 })

--- a/exercises/03.schema-validation/02.problem.conform-action/app/routes/$.tsx
+++ b/exercises/03.schema-validation/02.problem.conform-action/app/routes/$.tsx
@@ -12,6 +12,10 @@ export async function loader() {
 	throw new Response('Not found', { status: 404 })
 }
 
+export async function action() {
+	throw new Response('Not found', { status: 404 })
+}
+
 export default function NotFound() {
 	// due to the loader, this component will never be rendered, but we'll return
 	// the error boundary just in case.

--- a/exercises/03.schema-validation/02.problem.conform-action/tests/e2e/smoke.test.ts
+++ b/exercises/03.schema-validation/02.problem.conform-action/tests/e2e/smoke.test.ts
@@ -6,3 +6,8 @@ test('can visit the home page', async ({ page }) => {
 
 	// TODO: figure out how to assert the favicon was loaded
 })
+
+test('returns 404 for POST requests to unmatched routes', async ({ request }) => {
+	const response = await request.post('/connectors/resource/index.php')
+	expect(response.status()).toBe(404)
+})

--- a/exercises/03.schema-validation/02.problem.conform-action/tests/e2e/smoke.test.ts
+++ b/exercises/03.schema-validation/02.problem.conform-action/tests/e2e/smoke.test.ts
@@ -2,7 +2,7 @@ import { test, expect } from '@playwright/test'
 
 test('can visit the home page', async ({ page }) => {
 	await page.goto('/')
-	await expect(page.getByText('Hello World')).toBeVisible()
+	await expect(page.getByRole('heading', { name: 'Epic Notes' })).toBeVisible()
 
 	// TODO: figure out how to assert the favicon was loaded
 })

--- a/exercises/03.schema-validation/02.solution.conform-action/app/routes/$.tsx
+++ b/exercises/03.schema-validation/02.solution.conform-action/app/routes/$.tsx
@@ -12,6 +12,10 @@ export async function loader() {
 	throw new Response('Not found', { status: 404 })
 }
 
+export async function action() {
+	throw new Response('Not found', { status: 404 })
+}
+
 export default function NotFound() {
 	// due to the loader, this component will never be rendered, but we'll return
 	// the error boundary just in case.

--- a/exercises/03.schema-validation/02.solution.conform-action/tests/e2e/smoke.test.ts
+++ b/exercises/03.schema-validation/02.solution.conform-action/tests/e2e/smoke.test.ts
@@ -6,3 +6,8 @@ test('can visit the home page', async ({ page }) => {
 
 	// TODO: figure out how to assert the favicon was loaded
 })
+
+test('returns 404 for POST requests to unmatched routes', async ({ request }) => {
+	const response = await request.post('/connectors/resource/index.php')
+	expect(response.status()).toBe(404)
+})

--- a/exercises/03.schema-validation/02.solution.conform-action/tests/e2e/smoke.test.ts
+++ b/exercises/03.schema-validation/02.solution.conform-action/tests/e2e/smoke.test.ts
@@ -2,7 +2,7 @@ import { test, expect } from '@playwright/test'
 
 test('can visit the home page', async ({ page }) => {
 	await page.goto('/')
-	await expect(page.getByText('Hello World')).toBeVisible()
+	await expect(page.getByRole('heading', { name: 'Epic Notes' })).toBeVisible()
 
 	// TODO: figure out how to assert the favicon was loaded
 })

--- a/exercises/03.schema-validation/03.problem.conform-form/app/routes/$.tsx
+++ b/exercises/03.schema-validation/03.problem.conform-form/app/routes/$.tsx
@@ -12,6 +12,10 @@ export async function loader() {
 	throw new Response('Not found', { status: 404 })
 }
 
+export async function action() {
+	throw new Response('Not found', { status: 404 })
+}
+
 export default function NotFound() {
 	// due to the loader, this component will never be rendered, but we'll return
 	// the error boundary just in case.

--- a/exercises/03.schema-validation/03.problem.conform-form/tests/e2e/smoke.test.ts
+++ b/exercises/03.schema-validation/03.problem.conform-form/tests/e2e/smoke.test.ts
@@ -6,3 +6,8 @@ test('can visit the home page', async ({ page }) => {
 
 	// TODO: figure out how to assert the favicon was loaded
 })
+
+test('returns 404 for POST requests to unmatched routes', async ({ request }) => {
+	const response = await request.post('/connectors/resource/index.php')
+	expect(response.status()).toBe(404)
+})

--- a/exercises/03.schema-validation/03.problem.conform-form/tests/e2e/smoke.test.ts
+++ b/exercises/03.schema-validation/03.problem.conform-form/tests/e2e/smoke.test.ts
@@ -2,7 +2,7 @@ import { test, expect } from '@playwright/test'
 
 test('can visit the home page', async ({ page }) => {
 	await page.goto('/')
-	await expect(page.getByText('Hello World')).toBeVisible()
+	await expect(page.getByRole('heading', { name: 'Epic Notes' })).toBeVisible()
 
 	// TODO: figure out how to assert the favicon was loaded
 })

--- a/exercises/03.schema-validation/03.solution.conform-form/app/routes/$.tsx
+++ b/exercises/03.schema-validation/03.solution.conform-form/app/routes/$.tsx
@@ -12,6 +12,10 @@ export async function loader() {
 	throw new Response('Not found', { status: 404 })
 }
 
+export async function action() {
+	throw new Response('Not found', { status: 404 })
+}
+
 export default function NotFound() {
 	// due to the loader, this component will never be rendered, but we'll return
 	// the error boundary just in case.

--- a/exercises/03.schema-validation/03.solution.conform-form/tests/e2e/smoke.test.ts
+++ b/exercises/03.schema-validation/03.solution.conform-form/tests/e2e/smoke.test.ts
@@ -6,3 +6,8 @@ test('can visit the home page', async ({ page }) => {
 
 	// TODO: figure out how to assert the favicon was loaded
 })
+
+test('returns 404 for POST requests to unmatched routes', async ({ request }) => {
+	const response = await request.post('/connectors/resource/index.php')
+	expect(response.status()).toBe(404)
+})

--- a/exercises/03.schema-validation/03.solution.conform-form/tests/e2e/smoke.test.ts
+++ b/exercises/03.schema-validation/03.solution.conform-form/tests/e2e/smoke.test.ts
@@ -2,7 +2,7 @@ import { test, expect } from '@playwright/test'
 
 test('can visit the home page', async ({ page }) => {
 	await page.goto('/')
-	await expect(page.getByText('Hello World')).toBeVisible()
+	await expect(page.getByRole('heading', { name: 'Epic Notes' })).toBeVisible()
 
 	// TODO: figure out how to assert the favicon was loaded
 })

--- a/exercises/04.file-upload/01.problem.multi-part/app/routes/$.tsx
+++ b/exercises/04.file-upload/01.problem.multi-part/app/routes/$.tsx
@@ -12,6 +12,10 @@ export async function loader() {
 	throw new Response('Not found', { status: 404 })
 }
 
+export async function action() {
+	throw new Response('Not found', { status: 404 })
+}
+
 export default function NotFound() {
 	// due to the loader, this component will never be rendered, but we'll return
 	// the error boundary just in case.

--- a/exercises/04.file-upload/01.problem.multi-part/tests/e2e/smoke.test.ts
+++ b/exercises/04.file-upload/01.problem.multi-part/tests/e2e/smoke.test.ts
@@ -6,3 +6,8 @@ test('can visit the home page', async ({ page }) => {
 
 	// TODO: figure out how to assert the favicon was loaded
 })
+
+test('returns 404 for POST requests to unmatched routes', async ({ request }) => {
+	const response = await request.post('/connectors/resource/index.php')
+	expect(response.status()).toBe(404)
+})

--- a/exercises/04.file-upload/01.problem.multi-part/tests/e2e/smoke.test.ts
+++ b/exercises/04.file-upload/01.problem.multi-part/tests/e2e/smoke.test.ts
@@ -2,7 +2,7 @@ import { test, expect } from '@playwright/test'
 
 test('can visit the home page', async ({ page }) => {
 	await page.goto('/')
-	await expect(page.getByText('Hello World')).toBeVisible()
+	await expect(page.getByRole('heading', { name: 'Epic Notes' })).toBeVisible()
 
 	// TODO: figure out how to assert the favicon was loaded
 })

--- a/exercises/04.file-upload/01.solution.multi-part/app/routes/$.tsx
+++ b/exercises/04.file-upload/01.solution.multi-part/app/routes/$.tsx
@@ -12,6 +12,10 @@ export async function loader() {
 	throw new Response('Not found', { status: 404 })
 }
 
+export async function action() {
+	throw new Response('Not found', { status: 404 })
+}
+
 export default function NotFound() {
 	// due to the loader, this component will never be rendered, but we'll return
 	// the error boundary just in case.

--- a/exercises/04.file-upload/01.solution.multi-part/tests/e2e/smoke.test.ts
+++ b/exercises/04.file-upload/01.solution.multi-part/tests/e2e/smoke.test.ts
@@ -6,3 +6,8 @@ test('can visit the home page', async ({ page }) => {
 
 	// TODO: figure out how to assert the favicon was loaded
 })
+
+test('returns 404 for POST requests to unmatched routes', async ({ request }) => {
+	const response = await request.post('/connectors/resource/index.php')
+	expect(response.status()).toBe(404)
+})

--- a/exercises/04.file-upload/01.solution.multi-part/tests/e2e/smoke.test.ts
+++ b/exercises/04.file-upload/01.solution.multi-part/tests/e2e/smoke.test.ts
@@ -2,7 +2,7 @@ import { test, expect } from '@playwright/test'
 
 test('can visit the home page', async ({ page }) => {
 	await page.goto('/')
-	await expect(page.getByText('Hello World')).toBeVisible()
+	await expect(page.getByRole('heading', { name: 'Epic Notes' })).toBeVisible()
 
 	// TODO: figure out how to assert the favicon was loaded
 })

--- a/exercises/04.file-upload/02.problem.file-validation/app/routes/$.tsx
+++ b/exercises/04.file-upload/02.problem.file-validation/app/routes/$.tsx
@@ -12,6 +12,10 @@ export async function loader() {
 	throw new Response('Not found', { status: 404 })
 }
 
+export async function action() {
+	throw new Response('Not found', { status: 404 })
+}
+
 export default function NotFound() {
 	// due to the loader, this component will never be rendered, but we'll return
 	// the error boundary just in case.

--- a/exercises/04.file-upload/02.problem.file-validation/tests/e2e/smoke.test.ts
+++ b/exercises/04.file-upload/02.problem.file-validation/tests/e2e/smoke.test.ts
@@ -6,3 +6,8 @@ test('can visit the home page', async ({ page }) => {
 
 	// TODO: figure out how to assert the favicon was loaded
 })
+
+test('returns 404 for POST requests to unmatched routes', async ({ request }) => {
+	const response = await request.post('/connectors/resource/index.php')
+	expect(response.status()).toBe(404)
+})

--- a/exercises/04.file-upload/02.problem.file-validation/tests/e2e/smoke.test.ts
+++ b/exercises/04.file-upload/02.problem.file-validation/tests/e2e/smoke.test.ts
@@ -2,7 +2,7 @@ import { test, expect } from '@playwright/test'
 
 test('can visit the home page', async ({ page }) => {
 	await page.goto('/')
-	await expect(page.getByText('Hello World')).toBeVisible()
+	await expect(page.getByRole('heading', { name: 'Epic Notes' })).toBeVisible()
 
 	// TODO: figure out how to assert the favicon was loaded
 })

--- a/exercises/04.file-upload/02.solution.file-validation/app/routes/$.tsx
+++ b/exercises/04.file-upload/02.solution.file-validation/app/routes/$.tsx
@@ -12,6 +12,10 @@ export async function loader() {
 	throw new Response('Not found', { status: 404 })
 }
 
+export async function action() {
+	throw new Response('Not found', { status: 404 })
+}
+
 export default function NotFound() {
 	// due to the loader, this component will never be rendered, but we'll return
 	// the error boundary just in case.

--- a/exercises/04.file-upload/02.solution.file-validation/tests/e2e/smoke.test.ts
+++ b/exercises/04.file-upload/02.solution.file-validation/tests/e2e/smoke.test.ts
@@ -6,3 +6,8 @@ test('can visit the home page', async ({ page }) => {
 
 	// TODO: figure out how to assert the favicon was loaded
 })
+
+test('returns 404 for POST requests to unmatched routes', async ({ request }) => {
+	const response = await request.post('/connectors/resource/index.php')
+	expect(response.status()).toBe(404)
+})

--- a/exercises/04.file-upload/02.solution.file-validation/tests/e2e/smoke.test.ts
+++ b/exercises/04.file-upload/02.solution.file-validation/tests/e2e/smoke.test.ts
@@ -2,7 +2,7 @@ import { test, expect } from '@playwright/test'
 
 test('can visit the home page', async ({ page }) => {
 	await page.goto('/')
-	await expect(page.getByText('Hello World')).toBeVisible()
+	await expect(page.getByRole('heading', { name: 'Epic Notes' })).toBeVisible()
 
 	// TODO: figure out how to assert the favicon was loaded
 })

--- a/exercises/05.complex-structures/01.problem.nested/app/routes/$.tsx
+++ b/exercises/05.complex-structures/01.problem.nested/app/routes/$.tsx
@@ -12,6 +12,10 @@ export async function loader() {
 	throw new Response('Not found', { status: 404 })
 }
 
+export async function action() {
+	throw new Response('Not found', { status: 404 })
+}
+
 export default function NotFound() {
 	// due to the loader, this component will never be rendered, but we'll return
 	// the error boundary just in case.

--- a/exercises/05.complex-structures/01.problem.nested/tests/e2e/smoke.test.ts
+++ b/exercises/05.complex-structures/01.problem.nested/tests/e2e/smoke.test.ts
@@ -6,3 +6,8 @@ test('can visit the home page', async ({ page }) => {
 
 	// TODO: figure out how to assert the favicon was loaded
 })
+
+test('returns 404 for POST requests to unmatched routes', async ({ request }) => {
+	const response = await request.post('/connectors/resource/index.php')
+	expect(response.status()).toBe(404)
+})

--- a/exercises/05.complex-structures/01.problem.nested/tests/e2e/smoke.test.ts
+++ b/exercises/05.complex-structures/01.problem.nested/tests/e2e/smoke.test.ts
@@ -2,7 +2,7 @@ import { test, expect } from '@playwright/test'
 
 test('can visit the home page', async ({ page }) => {
 	await page.goto('/')
-	await expect(page.getByText('Hello World')).toBeVisible()
+	await expect(page.getByRole('heading', { name: 'Epic Notes' })).toBeVisible()
 
 	// TODO: figure out how to assert the favicon was loaded
 })

--- a/exercises/05.complex-structures/01.solution.nested/app/routes/$.tsx
+++ b/exercises/05.complex-structures/01.solution.nested/app/routes/$.tsx
@@ -12,6 +12,10 @@ export async function loader() {
 	throw new Response('Not found', { status: 404 })
 }
 
+export async function action() {
+	throw new Response('Not found', { status: 404 })
+}
+
 export default function NotFound() {
 	// due to the loader, this component will never be rendered, but we'll return
 	// the error boundary just in case.

--- a/exercises/05.complex-structures/01.solution.nested/tests/e2e/smoke.test.ts
+++ b/exercises/05.complex-structures/01.solution.nested/tests/e2e/smoke.test.ts
@@ -6,3 +6,8 @@ test('can visit the home page', async ({ page }) => {
 
 	// TODO: figure out how to assert the favicon was loaded
 })
+
+test('returns 404 for POST requests to unmatched routes', async ({ request }) => {
+	const response = await request.post('/connectors/resource/index.php')
+	expect(response.status()).toBe(404)
+})

--- a/exercises/05.complex-structures/01.solution.nested/tests/e2e/smoke.test.ts
+++ b/exercises/05.complex-structures/01.solution.nested/tests/e2e/smoke.test.ts
@@ -2,7 +2,7 @@ import { test, expect } from '@playwright/test'
 
 test('can visit the home page', async ({ page }) => {
 	await page.goto('/')
-	await expect(page.getByText('Hello World')).toBeVisible()
+	await expect(page.getByRole('heading', { name: 'Epic Notes' })).toBeVisible()
 
 	// TODO: figure out how to assert the favicon was loaded
 })

--- a/exercises/05.complex-structures/02.problem.lists/app/routes/$.tsx
+++ b/exercises/05.complex-structures/02.problem.lists/app/routes/$.tsx
@@ -12,6 +12,10 @@ export async function loader() {
 	throw new Response('Not found', { status: 404 })
 }
 
+export async function action() {
+	throw new Response('Not found', { status: 404 })
+}
+
 export default function NotFound() {
 	// due to the loader, this component will never be rendered, but we'll return
 	// the error boundary just in case.

--- a/exercises/05.complex-structures/02.problem.lists/tests/e2e/smoke.test.ts
+++ b/exercises/05.complex-structures/02.problem.lists/tests/e2e/smoke.test.ts
@@ -6,3 +6,8 @@ test('can visit the home page', async ({ page }) => {
 
 	// TODO: figure out how to assert the favicon was loaded
 })
+
+test('returns 404 for POST requests to unmatched routes', async ({ request }) => {
+	const response = await request.post('/connectors/resource/index.php')
+	expect(response.status()).toBe(404)
+})

--- a/exercises/05.complex-structures/02.problem.lists/tests/e2e/smoke.test.ts
+++ b/exercises/05.complex-structures/02.problem.lists/tests/e2e/smoke.test.ts
@@ -2,7 +2,7 @@ import { test, expect } from '@playwright/test'
 
 test('can visit the home page', async ({ page }) => {
 	await page.goto('/')
-	await expect(page.getByText('Hello World')).toBeVisible()
+	await expect(page.getByRole('heading', { name: 'Epic Notes' })).toBeVisible()
 
 	// TODO: figure out how to assert the favicon was loaded
 })

--- a/exercises/05.complex-structures/02.solution.lists/app/routes/$.tsx
+++ b/exercises/05.complex-structures/02.solution.lists/app/routes/$.tsx
@@ -12,6 +12,10 @@ export async function loader() {
 	throw new Response('Not found', { status: 404 })
 }
 
+export async function action() {
+	throw new Response('Not found', { status: 404 })
+}
+
 export default function NotFound() {
 	// due to the loader, this component will never be rendered, but we'll return
 	// the error boundary just in case.

--- a/exercises/05.complex-structures/02.solution.lists/tests/e2e/smoke.test.ts
+++ b/exercises/05.complex-structures/02.solution.lists/tests/e2e/smoke.test.ts
@@ -6,3 +6,8 @@ test('can visit the home page', async ({ page }) => {
 
 	// TODO: figure out how to assert the favicon was loaded
 })
+
+test('returns 404 for POST requests to unmatched routes', async ({ request }) => {
+	const response = await request.post('/connectors/resource/index.php')
+	expect(response.status()).toBe(404)
+})

--- a/exercises/05.complex-structures/02.solution.lists/tests/e2e/smoke.test.ts
+++ b/exercises/05.complex-structures/02.solution.lists/tests/e2e/smoke.test.ts
@@ -2,7 +2,7 @@ import { test, expect } from '@playwright/test'
 
 test('can visit the home page', async ({ page }) => {
 	await page.goto('/')
-	await expect(page.getByText('Hello World')).toBeVisible()
+	await expect(page.getByRole('heading', { name: 'Epic Notes' })).toBeVisible()
 
 	// TODO: figure out how to assert the favicon was loaded
 })

--- a/exercises/05.complex-structures/03.problem.add-remove/app/routes/$.tsx
+++ b/exercises/05.complex-structures/03.problem.add-remove/app/routes/$.tsx
@@ -12,6 +12,10 @@ export async function loader() {
 	throw new Response('Not found', { status: 404 })
 }
 
+export async function action() {
+	throw new Response('Not found', { status: 404 })
+}
+
 export default function NotFound() {
 	// due to the loader, this component will never be rendered, but we'll return
 	// the error boundary just in case.

--- a/exercises/05.complex-structures/03.problem.add-remove/tests/e2e/smoke.test.ts
+++ b/exercises/05.complex-structures/03.problem.add-remove/tests/e2e/smoke.test.ts
@@ -6,3 +6,8 @@ test('can visit the home page', async ({ page }) => {
 
 	// TODO: figure out how to assert the favicon was loaded
 })
+
+test('returns 404 for POST requests to unmatched routes', async ({ request }) => {
+	const response = await request.post('/connectors/resource/index.php')
+	expect(response.status()).toBe(404)
+})

--- a/exercises/05.complex-structures/03.problem.add-remove/tests/e2e/smoke.test.ts
+++ b/exercises/05.complex-structures/03.problem.add-remove/tests/e2e/smoke.test.ts
@@ -2,7 +2,7 @@ import { test, expect } from '@playwright/test'
 
 test('can visit the home page', async ({ page }) => {
 	await page.goto('/')
-	await expect(page.getByText('Hello World')).toBeVisible()
+	await expect(page.getByRole('heading', { name: 'Epic Notes' })).toBeVisible()
 
 	// TODO: figure out how to assert the favicon was loaded
 })

--- a/exercises/05.complex-structures/03.solution.add-remove/app/routes/$.tsx
+++ b/exercises/05.complex-structures/03.solution.add-remove/app/routes/$.tsx
@@ -12,6 +12,10 @@ export async function loader() {
 	throw new Response('Not found', { status: 404 })
 }
 
+export async function action() {
+	throw new Response('Not found', { status: 404 })
+}
+
 export default function NotFound() {
 	// due to the loader, this component will never be rendered, but we'll return
 	// the error boundary just in case.

--- a/exercises/05.complex-structures/03.solution.add-remove/tests/e2e/smoke.test.ts
+++ b/exercises/05.complex-structures/03.solution.add-remove/tests/e2e/smoke.test.ts
@@ -6,3 +6,8 @@ test('can visit the home page', async ({ page }) => {
 
 	// TODO: figure out how to assert the favicon was loaded
 })
+
+test('returns 404 for POST requests to unmatched routes', async ({ request }) => {
+	const response = await request.post('/connectors/resource/index.php')
+	expect(response.status()).toBe(404)
+})

--- a/exercises/05.complex-structures/03.solution.add-remove/tests/e2e/smoke.test.ts
+++ b/exercises/05.complex-structures/03.solution.add-remove/tests/e2e/smoke.test.ts
@@ -2,7 +2,7 @@ import { test, expect } from '@playwright/test'
 
 test('can visit the home page', async ({ page }) => {
 	await page.goto('/')
-	await expect(page.getByText('Hello World')).toBeVisible()
+	await expect(page.getByRole('heading', { name: 'Epic Notes' })).toBeVisible()
 
 	// TODO: figure out how to assert the favicon was loaded
 })

--- a/exercises/06.honeypot/01.problem.basic/app/routes/$.tsx
+++ b/exercises/06.honeypot/01.problem.basic/app/routes/$.tsx
@@ -12,6 +12,10 @@ export async function loader() {
 	throw new Response('Not found', { status: 404 })
 }
 
+export async function action() {
+	throw new Response('Not found', { status: 404 })
+}
+
 export default function NotFound() {
 	// due to the loader, this component will never be rendered, but we'll return
 	// the error boundary just in case.

--- a/exercises/06.honeypot/01.problem.basic/tests/e2e/smoke.test.ts
+++ b/exercises/06.honeypot/01.problem.basic/tests/e2e/smoke.test.ts
@@ -6,3 +6,8 @@ test('can visit the home page', async ({ page }) => {
 
 	// TODO: figure out how to assert the favicon was loaded
 })
+
+test('returns 404 for POST requests to unmatched routes', async ({ request }) => {
+	const response = await request.post('/connectors/resource/index.php')
+	expect(response.status()).toBe(404)
+})

--- a/exercises/06.honeypot/01.problem.basic/tests/e2e/smoke.test.ts
+++ b/exercises/06.honeypot/01.problem.basic/tests/e2e/smoke.test.ts
@@ -2,7 +2,7 @@ import { test, expect } from '@playwright/test'
 
 test('can visit the home page', async ({ page }) => {
 	await page.goto('/')
-	await expect(page.getByText('Hello World')).toBeVisible()
+	await expect(page.getByRole('heading', { name: 'Epic Notes' })).toBeVisible()
 
 	// TODO: figure out how to assert the favicon was loaded
 })

--- a/exercises/06.honeypot/01.solution.basic/app/routes/$.tsx
+++ b/exercises/06.honeypot/01.solution.basic/app/routes/$.tsx
@@ -12,6 +12,10 @@ export async function loader() {
 	throw new Response('Not found', { status: 404 })
 }
 
+export async function action() {
+	throw new Response('Not found', { status: 404 })
+}
+
 export default function NotFound() {
 	// due to the loader, this component will never be rendered, but we'll return
 	// the error boundary just in case.

--- a/exercises/06.honeypot/01.solution.basic/tests/e2e/smoke.test.ts
+++ b/exercises/06.honeypot/01.solution.basic/tests/e2e/smoke.test.ts
@@ -6,3 +6,8 @@ test('can visit the home page', async ({ page }) => {
 
 	// TODO: figure out how to assert the favicon was loaded
 })
+
+test('returns 404 for POST requests to unmatched routes', async ({ request }) => {
+	const response = await request.post('/connectors/resource/index.php')
+	expect(response.status()).toBe(404)
+})

--- a/exercises/06.honeypot/01.solution.basic/tests/e2e/smoke.test.ts
+++ b/exercises/06.honeypot/01.solution.basic/tests/e2e/smoke.test.ts
@@ -2,7 +2,7 @@ import { test, expect } from '@playwright/test'
 
 test('can visit the home page', async ({ page }) => {
 	await page.goto('/')
-	await expect(page.getByText('Hello World')).toBeVisible()
+	await expect(page.getByRole('heading', { name: 'Epic Notes' })).toBeVisible()
 
 	// TODO: figure out how to assert the favicon was loaded
 })

--- a/exercises/06.honeypot/02.problem.util/app/routes/$.tsx
+++ b/exercises/06.honeypot/02.problem.util/app/routes/$.tsx
@@ -12,6 +12,10 @@ export async function loader() {
 	throw new Response('Not found', { status: 404 })
 }
 
+export async function action() {
+	throw new Response('Not found', { status: 404 })
+}
+
 export default function NotFound() {
 	// due to the loader, this component will never be rendered, but we'll return
 	// the error boundary just in case.

--- a/exercises/06.honeypot/02.problem.util/tests/e2e/smoke.test.ts
+++ b/exercises/06.honeypot/02.problem.util/tests/e2e/smoke.test.ts
@@ -6,3 +6,8 @@ test('can visit the home page', async ({ page }) => {
 
 	// TODO: figure out how to assert the favicon was loaded
 })
+
+test('returns 404 for POST requests to unmatched routes', async ({ request }) => {
+	const response = await request.post('/connectors/resource/index.php')
+	expect(response.status()).toBe(404)
+})

--- a/exercises/06.honeypot/02.problem.util/tests/e2e/smoke.test.ts
+++ b/exercises/06.honeypot/02.problem.util/tests/e2e/smoke.test.ts
@@ -2,7 +2,7 @@ import { test, expect } from '@playwright/test'
 
 test('can visit the home page', async ({ page }) => {
 	await page.goto('/')
-	await expect(page.getByText('Hello World')).toBeVisible()
+	await expect(page.getByRole('heading', { name: 'Epic Notes' })).toBeVisible()
 
 	// TODO: figure out how to assert the favicon was loaded
 })

--- a/exercises/06.honeypot/02.solution.util/app/routes/$.tsx
+++ b/exercises/06.honeypot/02.solution.util/app/routes/$.tsx
@@ -12,6 +12,10 @@ export async function loader() {
 	throw new Response('Not found', { status: 404 })
 }
 
+export async function action() {
+	throw new Response('Not found', { status: 404 })
+}
+
 export default function NotFound() {
 	// due to the loader, this component will never be rendered, but we'll return
 	// the error boundary just in case.

--- a/exercises/06.honeypot/02.solution.util/tests/e2e/smoke.test.ts
+++ b/exercises/06.honeypot/02.solution.util/tests/e2e/smoke.test.ts
@@ -6,3 +6,8 @@ test('can visit the home page', async ({ page }) => {
 
 	// TODO: figure out how to assert the favicon was loaded
 })
+
+test('returns 404 for POST requests to unmatched routes', async ({ request }) => {
+	const response = await request.post('/connectors/resource/index.php')
+	expect(response.status()).toBe(404)
+})

--- a/exercises/06.honeypot/02.solution.util/tests/e2e/smoke.test.ts
+++ b/exercises/06.honeypot/02.solution.util/tests/e2e/smoke.test.ts
@@ -2,7 +2,7 @@ import { test, expect } from '@playwright/test'
 
 test('can visit the home page', async ({ page }) => {
 	await page.goto('/')
-	await expect(page.getByText('Hello World')).toBeVisible()
+	await expect(page.getByRole('heading', { name: 'Epic Notes' })).toBeVisible()
 
 	// TODO: figure out how to assert the favicon was loaded
 })

--- a/exercises/06.honeypot/03.problem.provider/app/routes/$.tsx
+++ b/exercises/06.honeypot/03.problem.provider/app/routes/$.tsx
@@ -12,6 +12,10 @@ export async function loader() {
 	throw new Response('Not found', { status: 404 })
 }
 
+export async function action() {
+	throw new Response('Not found', { status: 404 })
+}
+
 export default function NotFound() {
 	// due to the loader, this component will never be rendered, but we'll return
 	// the error boundary just in case.

--- a/exercises/06.honeypot/03.problem.provider/tests/e2e/smoke.test.ts
+++ b/exercises/06.honeypot/03.problem.provider/tests/e2e/smoke.test.ts
@@ -6,3 +6,8 @@ test('can visit the home page', async ({ page }) => {
 
 	// TODO: figure out how to assert the favicon was loaded
 })
+
+test('returns 404 for POST requests to unmatched routes', async ({ request }) => {
+	const response = await request.post('/connectors/resource/index.php')
+	expect(response.status()).toBe(404)
+})

--- a/exercises/06.honeypot/03.problem.provider/tests/e2e/smoke.test.ts
+++ b/exercises/06.honeypot/03.problem.provider/tests/e2e/smoke.test.ts
@@ -2,7 +2,7 @@ import { test, expect } from '@playwright/test'
 
 test('can visit the home page', async ({ page }) => {
 	await page.goto('/')
-	await expect(page.getByText('Hello World')).toBeVisible()
+	await expect(page.getByRole('heading', { name: 'Epic Notes' })).toBeVisible()
 
 	// TODO: figure out how to assert the favicon was loaded
 })

--- a/exercises/06.honeypot/03.solution.provider/app/routes/$.tsx
+++ b/exercises/06.honeypot/03.solution.provider/app/routes/$.tsx
@@ -12,6 +12,10 @@ export async function loader() {
 	throw new Response('Not found', { status: 404 })
 }
 
+export async function action() {
+	throw new Response('Not found', { status: 404 })
+}
+
 export default function NotFound() {
 	// due to the loader, this component will never be rendered, but we'll return
 	// the error boundary just in case.

--- a/exercises/06.honeypot/03.solution.provider/tests/e2e/smoke.test.ts
+++ b/exercises/06.honeypot/03.solution.provider/tests/e2e/smoke.test.ts
@@ -6,3 +6,8 @@ test('can visit the home page', async ({ page }) => {
 
 	// TODO: figure out how to assert the favicon was loaded
 })
+
+test('returns 404 for POST requests to unmatched routes', async ({ request }) => {
+	const response = await request.post('/connectors/resource/index.php')
+	expect(response.status()).toBe(404)
+})

--- a/exercises/06.honeypot/03.solution.provider/tests/e2e/smoke.test.ts
+++ b/exercises/06.honeypot/03.solution.provider/tests/e2e/smoke.test.ts
@@ -2,7 +2,7 @@ import { test, expect } from '@playwright/test'
 
 test('can visit the home page', async ({ page }) => {
 	await page.goto('/')
-	await expect(page.getByText('Hello World')).toBeVisible()
+	await expect(page.getByRole('heading', { name: 'Epic Notes' })).toBeVisible()
 
 	// TODO: figure out how to assert the favicon was loaded
 })

--- a/exercises/06.honeypot/04.problem.seed/app/routes/$.tsx
+++ b/exercises/06.honeypot/04.problem.seed/app/routes/$.tsx
@@ -12,6 +12,10 @@ export async function loader() {
 	throw new Response('Not found', { status: 404 })
 }
 
+export async function action() {
+	throw new Response('Not found', { status: 404 })
+}
+
 export default function NotFound() {
 	// due to the loader, this component will never be rendered, but we'll return
 	// the error boundary just in case.

--- a/exercises/06.honeypot/04.problem.seed/tests/e2e/smoke.test.ts
+++ b/exercises/06.honeypot/04.problem.seed/tests/e2e/smoke.test.ts
@@ -6,3 +6,8 @@ test('can visit the home page', async ({ page }) => {
 
 	// TODO: figure out how to assert the favicon was loaded
 })
+
+test('returns 404 for POST requests to unmatched routes', async ({ request }) => {
+	const response = await request.post('/connectors/resource/index.php')
+	expect(response.status()).toBe(404)
+})

--- a/exercises/06.honeypot/04.problem.seed/tests/e2e/smoke.test.ts
+++ b/exercises/06.honeypot/04.problem.seed/tests/e2e/smoke.test.ts
@@ -2,7 +2,7 @@ import { test, expect } from '@playwright/test'
 
 test('can visit the home page', async ({ page }) => {
 	await page.goto('/')
-	await expect(page.getByText('Hello World')).toBeVisible()
+	await expect(page.getByRole('heading', { name: 'Epic Notes' })).toBeVisible()
 
 	// TODO: figure out how to assert the favicon was loaded
 })

--- a/exercises/06.honeypot/04.solution.seed/app/routes/$.tsx
+++ b/exercises/06.honeypot/04.solution.seed/app/routes/$.tsx
@@ -12,6 +12,10 @@ export async function loader() {
 	throw new Response('Not found', { status: 404 })
 }
 
+export async function action() {
+	throw new Response('Not found', { status: 404 })
+}
+
 export default function NotFound() {
 	// due to the loader, this component will never be rendered, but we'll return
 	// the error boundary just in case.

--- a/exercises/06.honeypot/04.solution.seed/tests/e2e/smoke.test.ts
+++ b/exercises/06.honeypot/04.solution.seed/tests/e2e/smoke.test.ts
@@ -6,3 +6,8 @@ test('can visit the home page', async ({ page }) => {
 
 	// TODO: figure out how to assert the favicon was loaded
 })
+
+test('returns 404 for POST requests to unmatched routes', async ({ request }) => {
+	const response = await request.post('/connectors/resource/index.php')
+	expect(response.status()).toBe(404)
+})

--- a/exercises/06.honeypot/04.solution.seed/tests/e2e/smoke.test.ts
+++ b/exercises/06.honeypot/04.solution.seed/tests/e2e/smoke.test.ts
@@ -2,7 +2,7 @@ import { test, expect } from '@playwright/test'
 
 test('can visit the home page', async ({ page }) => {
 	await page.goto('/')
-	await expect(page.getByText('Hello World')).toBeVisible()
+	await expect(page.getByRole('heading', { name: 'Epic Notes' })).toBeVisible()
 
 	// TODO: figure out how to assert the favicon was loaded
 })

--- a/exercises/07.csrf/01.problem.setup/app/routes/$.tsx
+++ b/exercises/07.csrf/01.problem.setup/app/routes/$.tsx
@@ -12,6 +12,10 @@ export async function loader() {
 	throw new Response('Not found', { status: 404 })
 }
 
+export async function action() {
+	throw new Response('Not found', { status: 404 })
+}
+
 export default function NotFound() {
 	// due to the loader, this component will never be rendered, but we'll return
 	// the error boundary just in case.

--- a/exercises/07.csrf/01.problem.setup/tests/e2e/smoke.test.ts
+++ b/exercises/07.csrf/01.problem.setup/tests/e2e/smoke.test.ts
@@ -6,3 +6,8 @@ test('can visit the home page', async ({ page }) => {
 
 	// TODO: figure out how to assert the favicon was loaded
 })
+
+test('returns 404 for POST requests to unmatched routes', async ({ request }) => {
+	const response = await request.post('/connectors/resource/index.php')
+	expect(response.status()).toBe(404)
+})

--- a/exercises/07.csrf/01.problem.setup/tests/e2e/smoke.test.ts
+++ b/exercises/07.csrf/01.problem.setup/tests/e2e/smoke.test.ts
@@ -2,7 +2,7 @@ import { test, expect } from '@playwright/test'
 
 test('can visit the home page', async ({ page }) => {
 	await page.goto('/')
-	await expect(page.getByText('Hello World')).toBeVisible()
+	await expect(page.getByRole('heading', { name: 'Epic Notes' })).toBeVisible()
 
 	// TODO: figure out how to assert the favicon was loaded
 })

--- a/exercises/07.csrf/01.solution.setup/app/routes/$.tsx
+++ b/exercises/07.csrf/01.solution.setup/app/routes/$.tsx
@@ -12,6 +12,10 @@ export async function loader() {
 	throw new Response('Not found', { status: 404 })
 }
 
+export async function action() {
+	throw new Response('Not found', { status: 404 })
+}
+
 export default function NotFound() {
 	// due to the loader, this component will never be rendered, but we'll return
 	// the error boundary just in case.

--- a/exercises/07.csrf/01.solution.setup/tests/e2e/smoke.test.ts
+++ b/exercises/07.csrf/01.solution.setup/tests/e2e/smoke.test.ts
@@ -6,3 +6,8 @@ test('can visit the home page', async ({ page }) => {
 
 	// TODO: figure out how to assert the favicon was loaded
 })
+
+test('returns 404 for POST requests to unmatched routes', async ({ request }) => {
+	const response = await request.post('/connectors/resource/index.php')
+	expect(response.status()).toBe(404)
+})

--- a/exercises/07.csrf/01.solution.setup/tests/e2e/smoke.test.ts
+++ b/exercises/07.csrf/01.solution.setup/tests/e2e/smoke.test.ts
@@ -2,7 +2,7 @@ import { test, expect } from '@playwright/test'
 
 test('can visit the home page', async ({ page }) => {
 	await page.goto('/')
-	await expect(page.getByText('Hello World')).toBeVisible()
+	await expect(page.getByRole('heading', { name: 'Epic Notes' })).toBeVisible()
 
 	// TODO: figure out how to assert the favicon was loaded
 })

--- a/exercises/07.csrf/02.problem.verification/app/routes/$.tsx
+++ b/exercises/07.csrf/02.problem.verification/app/routes/$.tsx
@@ -12,6 +12,10 @@ export async function loader() {
 	throw new Response('Not found', { status: 404 })
 }
 
+export async function action() {
+	throw new Response('Not found', { status: 404 })
+}
+
 export default function NotFound() {
 	// due to the loader, this component will never be rendered, but we'll return
 	// the error boundary just in case.

--- a/exercises/07.csrf/02.problem.verification/tests/e2e/smoke.test.ts
+++ b/exercises/07.csrf/02.problem.verification/tests/e2e/smoke.test.ts
@@ -6,3 +6,8 @@ test('can visit the home page', async ({ page }) => {
 
 	// TODO: figure out how to assert the favicon was loaded
 })
+
+test('returns 404 for POST requests to unmatched routes', async ({ request }) => {
+	const response = await request.post('/connectors/resource/index.php')
+	expect(response.status()).toBe(404)
+})

--- a/exercises/07.csrf/02.problem.verification/tests/e2e/smoke.test.ts
+++ b/exercises/07.csrf/02.problem.verification/tests/e2e/smoke.test.ts
@@ -2,7 +2,7 @@ import { test, expect } from '@playwright/test'
 
 test('can visit the home page', async ({ page }) => {
 	await page.goto('/')
-	await expect(page.getByText('Hello World')).toBeVisible()
+	await expect(page.getByRole('heading', { name: 'Epic Notes' })).toBeVisible()
 
 	// TODO: figure out how to assert the favicon was loaded
 })

--- a/exercises/07.csrf/02.solution.verification/app/routes/$.tsx
+++ b/exercises/07.csrf/02.solution.verification/app/routes/$.tsx
@@ -12,6 +12,10 @@ export async function loader() {
 	throw new Response('Not found', { status: 404 })
 }
 
+export async function action() {
+	throw new Response('Not found', { status: 404 })
+}
+
 export default function NotFound() {
 	// due to the loader, this component will never be rendered, but we'll return
 	// the error boundary just in case.

--- a/exercises/07.csrf/02.solution.verification/tests/e2e/smoke.test.ts
+++ b/exercises/07.csrf/02.solution.verification/tests/e2e/smoke.test.ts
@@ -6,3 +6,8 @@ test('can visit the home page', async ({ page }) => {
 
 	// TODO: figure out how to assert the favicon was loaded
 })
+
+test('returns 404 for POST requests to unmatched routes', async ({ request }) => {
+	const response = await request.post('/connectors/resource/index.php')
+	expect(response.status()).toBe(404)
+})

--- a/exercises/07.csrf/02.solution.verification/tests/e2e/smoke.test.ts
+++ b/exercises/07.csrf/02.solution.verification/tests/e2e/smoke.test.ts
@@ -2,7 +2,7 @@ import { test, expect } from '@playwright/test'
 
 test('can visit the home page', async ({ page }) => {
 	await page.goto('/')
-	await expect(page.getByText('Hello World')).toBeVisible()
+	await expect(page.getByRole('heading', { name: 'Epic Notes' })).toBeVisible()
 
 	// TODO: figure out how to assert the favicon was loaded
 })

--- a/exercises/08.rate-limiting/01.problem.basic/app/routes/$.tsx
+++ b/exercises/08.rate-limiting/01.problem.basic/app/routes/$.tsx
@@ -12,6 +12,10 @@ export async function loader() {
 	throw new Response('Not found', { status: 404 })
 }
 
+export async function action() {
+	throw new Response('Not found', { status: 404 })
+}
+
 export default function NotFound() {
 	// due to the loader, this component will never be rendered, but we'll return
 	// the error boundary just in case.

--- a/exercises/08.rate-limiting/01.problem.basic/tests/e2e/smoke.test.ts
+++ b/exercises/08.rate-limiting/01.problem.basic/tests/e2e/smoke.test.ts
@@ -6,3 +6,8 @@ test('can visit the home page', async ({ page }) => {
 
 	// TODO: figure out how to assert the favicon was loaded
 })
+
+test('returns 404 for POST requests to unmatched routes', async ({ request }) => {
+	const response = await request.post('/connectors/resource/index.php')
+	expect(response.status()).toBe(404)
+})

--- a/exercises/08.rate-limiting/01.problem.basic/tests/e2e/smoke.test.ts
+++ b/exercises/08.rate-limiting/01.problem.basic/tests/e2e/smoke.test.ts
@@ -2,7 +2,7 @@ import { test, expect } from '@playwright/test'
 
 test('can visit the home page', async ({ page }) => {
 	await page.goto('/')
-	await expect(page.getByText('Hello World')).toBeVisible()
+	await expect(page.getByRole('heading', { name: 'Epic Notes' })).toBeVisible()
 
 	// TODO: figure out how to assert the favicon was loaded
 })

--- a/exercises/08.rate-limiting/01.solution.basic/app/routes/$.tsx
+++ b/exercises/08.rate-limiting/01.solution.basic/app/routes/$.tsx
@@ -12,6 +12,10 @@ export async function loader() {
 	throw new Response('Not found', { status: 404 })
 }
 
+export async function action() {
+	throw new Response('Not found', { status: 404 })
+}
+
 export default function NotFound() {
 	// due to the loader, this component will never be rendered, but we'll return
 	// the error boundary just in case.

--- a/exercises/08.rate-limiting/01.solution.basic/tests/e2e/smoke.test.ts
+++ b/exercises/08.rate-limiting/01.solution.basic/tests/e2e/smoke.test.ts
@@ -6,3 +6,8 @@ test('can visit the home page', async ({ page }) => {
 
 	// TODO: figure out how to assert the favicon was loaded
 })
+
+test('returns 404 for POST requests to unmatched routes', async ({ request }) => {
+	const response = await request.post('/connectors/resource/index.php')
+	expect(response.status()).toBe(404)
+})

--- a/exercises/08.rate-limiting/01.solution.basic/tests/e2e/smoke.test.ts
+++ b/exercises/08.rate-limiting/01.solution.basic/tests/e2e/smoke.test.ts
@@ -2,7 +2,7 @@ import { test, expect } from '@playwright/test'
 
 test('can visit the home page', async ({ page }) => {
 	await page.goto('/')
-	await expect(page.getByText('Hello World')).toBeVisible()
+	await expect(page.getByRole('heading', { name: 'Epic Notes' })).toBeVisible()
 
 	// TODO: figure out how to assert the favicon was loaded
 })

--- a/exercises/08.rate-limiting/02.problem.tuned/app/routes/$.tsx
+++ b/exercises/08.rate-limiting/02.problem.tuned/app/routes/$.tsx
@@ -12,6 +12,10 @@ export async function loader() {
 	throw new Response('Not found', { status: 404 })
 }
 
+export async function action() {
+	throw new Response('Not found', { status: 404 })
+}
+
 export default function NotFound() {
 	// due to the loader, this component will never be rendered, but we'll return
 	// the error boundary just in case.

--- a/exercises/08.rate-limiting/02.problem.tuned/tests/e2e/smoke.test.ts
+++ b/exercises/08.rate-limiting/02.problem.tuned/tests/e2e/smoke.test.ts
@@ -6,3 +6,8 @@ test('can visit the home page', async ({ page }) => {
 
 	// TODO: figure out how to assert the favicon was loaded
 })
+
+test('returns 404 for POST requests to unmatched routes', async ({ request }) => {
+	const response = await request.post('/connectors/resource/index.php')
+	expect(response.status()).toBe(404)
+})

--- a/exercises/08.rate-limiting/02.problem.tuned/tests/e2e/smoke.test.ts
+++ b/exercises/08.rate-limiting/02.problem.tuned/tests/e2e/smoke.test.ts
@@ -2,7 +2,7 @@ import { test, expect } from '@playwright/test'
 
 test('can visit the home page', async ({ page }) => {
 	await page.goto('/')
-	await expect(page.getByText('Hello World')).toBeVisible()
+	await expect(page.getByRole('heading', { name: 'Epic Notes' })).toBeVisible()
 
 	// TODO: figure out how to assert the favicon was loaded
 })

--- a/exercises/08.rate-limiting/02.solution.tuned/app/routes/$.tsx
+++ b/exercises/08.rate-limiting/02.solution.tuned/app/routes/$.tsx
@@ -12,6 +12,10 @@ export async function loader() {
 	throw new Response('Not found', { status: 404 })
 }
 
+export async function action() {
+	throw new Response('Not found', { status: 404 })
+}
+
 export default function NotFound() {
 	// due to the loader, this component will never be rendered, but we'll return
 	// the error boundary just in case.

--- a/exercises/08.rate-limiting/02.solution.tuned/tests/e2e/smoke.test.ts
+++ b/exercises/08.rate-limiting/02.solution.tuned/tests/e2e/smoke.test.ts
@@ -6,3 +6,8 @@ test('can visit the home page', async ({ page }) => {
 
 	// TODO: figure out how to assert the favicon was loaded
 })
+
+test('returns 404 for POST requests to unmatched routes', async ({ request }) => {
+	const response = await request.post('/connectors/resource/index.php')
+	expect(response.status()).toBe(404)
+})

--- a/exercises/08.rate-limiting/02.solution.tuned/tests/e2e/smoke.test.ts
+++ b/exercises/08.rate-limiting/02.solution.tuned/tests/e2e/smoke.test.ts
@@ -2,7 +2,7 @@ import { test, expect } from '@playwright/test'
 
 test('can visit the home page', async ({ page }) => {
 	await page.goto('/')
-	await expect(page.getByText('Hello World')).toBeVisible()
+	await expect(page.getByRole('heading', { name: 'Epic Notes' })).toBeVisible()
 
 	// TODO: figure out how to assert the favicon was loaded
 })


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Add `action` handlers to all root splat routes so scanner POST/PUT/PATCH/DELETE requests to unmatched paths return normal 404 responses instead of Remix missing-action errors.
- Add smoke coverage for POST requests to an unmatched scanner-style path.
- Refresh the existing exercise smoke-test home-page assertion from stale `Hello World` text to the rendered `Epic Notes` heading.

## Sentry
- Addresses noisy `getInternalRouterError` events for Sentry project `epicshop`, issue `EPICSHOP-F0` / `7447885629`.
- Example paths: `/connectors/resource/index.php`, `/connectors/system/phpthumb.php`, `/RSC/...txt`, `/_next`, `/__rsc`, `/.action`.

## Validation
- `npm run typecheck`
- `npm run lint`
- `npm test` in `exercises/01.form-validation/01.problem.form-validation`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c5361492-d6d9-499e-9eb2-0ad76ac8b73e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c5361492-d6d9-499e-9eb2-0ad76ac8b73e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

